### PR TITLE
Added Lambda function to track the latest AMI

### DIFF
--- a/lambda/latest_image_tracker/README.md
+++ b/lambda/latest_image_tracker/README.md
@@ -1,0 +1,44 @@
+# Latest Image Tracker
+
+This is a sample solution that uses AWS Lambda and AWS Systems Manager (SSM) Parameter Store to track and update the latest Amazon Machine Image (AMI) IDs every time an Image Builder pipeline is run. Users can reference the SSM parameter in automation scripts and AWS CloudFormation templates providing access to the latest AMI ID for your EC2 infrastructure. 
+
+This solution uses a Lambda function written in Python that subscribes to an Amazon Simple Notification Service (SNS) topic. The Lambda function and the SNS topic are deployed using AWS SAM CLI. Once deployed, the SNS topic must be configured in an existing Image Builder pipeline. This results in the Lambda function being invoked at the completion of the Image Builder pipeline
+
+
+## Prerequisites
+
+To get started with this solution, the following is required:
+1. [AWS SAM CLI](https://aws.amazon.com/serverless/sam/) to deploy the solution.
+2. An existing Amazon EC2 Image Builder pipeline.
+
+
+
+## Walkthrough
+
+The solution consists of two files:
+
+1. The Python file ```image-builder-lambda-update-ssm.py``` contains the code for the Lambda function. It first checks the SNS message payload to determine if the image is available. If it’s available, it extracts the AMI ID from the SNS message payload and updates the SSM parameter specified. 
+
+The ```sm_parameter_name``` variable specifies the SSM parameter path where the AMI ID should be stored and updated. The Lambda function finishes by adding tags to the SSM parameter.
+
+2. The ```template.yaml``` file is an AWS SAM template. It deploys the Lambda function, SNS topic, and IAM role required for the Lambda function. I use Python 3.7 as the runtime and assign a memory of 256 MB for the Lambda function. The IAM policy gives the Lambda function permissions to retrieve and update SSM parameters. 
+
+
+## Deploying the Solution
+
+1. Deploy this application using the [AWS SAM CLI guided deploy](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-cli-command-reference-sam-deploy.html)
+
+```bash
+sam deploy -g
+```
+2. After deploying the application, note the ARN of the created SNS topic. Next, update the infrastructure settings of an existing Image Builder pipeline with this newly created SNS topic. This results in the Lambda function being invoked upon the completion of the image builder pipeline. 
+
+
+## Verifying the Solution
+
+After the completion of the image builder pipeline, use the AWS CLI or check the AWS Management Console to verify the updated SSM parameter. To verify via AWS CLI, run the following commands to retrieve and list the tags attached to the SSM parameter:
+
+```bash
+aws ssm get-parameter --name ‘/ec2-imagebuilder/latest’
+aws ssm list-tags-for-resource --resource-type "Parameter" --resource-id ‘/ec2-imagebuilder/latest’
+```

--- a/lambda/latest_image_tracker/image-builder-lambda-update-ssm.py
+++ b/lambda/latest_image_tracker/image-builder-lambda-update-ssm.py
@@ -1,0 +1,80 @@
+import json
+import boto3
+import logging 
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+ssm_client = boto3.client('ssm')
+ssm_parameter_name = '/ec2-imagebuilder/latest'
+
+def lambda_handler(event, context):
+    logger.info('Printing event: {}'.format(event))
+    process_sns_event(event)
+    return None
+
+
+def process_sns_event(event):
+    for record in (event['Records']):
+        event_message = record['Sns']['Message']
+
+        #convert the event message to json
+        message_json = json.loads(event_message)
+
+        #obtain the image state
+        image_state = (message_json['state']['status'])
+     
+        #update the SSM parameter if the image state is available
+        if (image_state == 'AVAILABLE'):
+            logger.info('Image is available')
+
+            #obtain ami id
+            ami = message_json['outputResources']['amis'][0]
+            recipe_name = message_json['name']
+            logger.info('AMI ID: {}'.format(ami['image']))
+
+            #update SSM parameter
+            response = ssm_client.put_parameter(
+                Name=ssm_parameter_name,
+                Description='Latest AMI ID',
+                Value=ami['image'],
+                Type='String',
+                Overwrite=True,
+                Tier='Standard'
+                )
+            logger.info('SSM Updated: {}'.format(response))
+
+            #add tags to the SSM parameter
+            ssm_client.add_tags_to_resource(
+            ResourceType='Parameter',
+            ResourceId=ssm_parameter_name,
+            Tags=[
+                {
+                    'Key': 'Source',
+                    'Value': 'EC2 Image Builder'
+                },
+                {
+                    'Key': 'AMI_REGION',
+                    'Value': ami['region']
+                },
+                {
+                    'Key': 'AMI_ID',
+                    'Value': ami['image']
+                },
+                {
+                    'Key': 'AMI_NAME',
+                    'Value': ami['name']
+                },
+                {
+                    'Key': 'RECIPE_NAME',
+                    'Value': recipe_name
+                },
+                {
+                    'Key': 'SOURCE_PIPELINE_ARN',
+                    'Value': message_json['sourcePipelineArn']
+                },
+            ],
+        )
+
+    # end of Lambda function    
+    return None

--- a/lambda/latest_image_tracker/template.yml
+++ b/lambda/latest_image_tracker/template.yml
@@ -24,7 +24,7 @@ Resources:
           Properties:
             Topic: !Ref ImageBuilderSNSTopic
       Policies:
-          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+          - arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
           - Version: '2012-10-17'
             Statement:
               - Effect: Allow

--- a/lambda/latest_image_tracker/template.yml
+++ b/lambda/latest_image_tracker/template.yml
@@ -1,0 +1,51 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: "AWS::Serverless-2016-10-31"
+Description: Resources for Lambda function to update SSM Parameter
+
+Resources:
+  ImageBuilderSNSTopic:
+    Type: "AWS::SNS::Topic"
+    Properties:
+      DisplayName: "Image Builder"
+
+  UpdateSSMParameter:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      Handler: image-builder-lambda-update-ssm.lambda_handler
+      Runtime: python3.7
+      CodeUri: .
+      Description: Update SSM Parameter with the latest AMI
+      MemorySize: 256
+      Timeout: 300
+      AutoPublishAlias: live
+      Events:
+        SNSTopicEvent:
+          Type: SNS
+          Properties:
+            Topic: !Ref ImageBuilderSNSTopic
+      Policies:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+          - Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:PutParameter
+                  - ssm:AddTagsToResource
+                  - ssm:GetParameters
+                Resource: '*'
+
+Outputs:
+  LambdaArn:
+    Description: Lambda Function Arn
+    Value: !GetAtt UpdateSSMParameter.Arn
+    Export:
+      Name: image-builder-lambda-update-ssm-arn
+
+  SNSTopicArn:
+    Description: SNS Topic Arn
+    Value: !Ref ImageBuilderSNSTopic
+    Export:
+      Name: image-builder-lambda-sns-arn
+
+
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is a sample solution that uses AWS Lambda and AWS Systems Manager (SSM) Parameter Store to track and update the latest Amazon Machine Image (AMI) IDs every time an Image Builder pipeline is run. Users can reference the SSM parameter in automation scripts and AWS CloudFormation templates providing access to the latest AMI ID for your EC2 infrastructure. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
