### PR TITLE
Added .NET samples for Ubuntu container images and cascading Windows …

### DIFF
--- a/CloudFormation/Docker/ubuntu-dotnet-web-application/README.md
+++ b/CloudFormation/Docker/ubuntu-dotnet-web-application/README.md
@@ -1,0 +1,117 @@
+# Ubuntu 18.04 Container Image Pipeline for hosting a .NET web application
+
+This is a sample template that demonstrates how to use EC2 Image Builder CloudFormation resources to build an Ubuntu 18.04 Docker container image that can host a .NET web application. The image will be published to the specified Amazon Elastic Container Registry (ECR) repository.
+
+***Internet connectivity is required in your default VPC*** to pull the source image by digest from a Docker Hub repository. If you do not have a default VPC, or want to use a custom VPC, you will need to specify a subnet ID and one or more security group IDs in the VPC as parameters when you create a stack based on this template.
+
+## How this Stack Works
+
+First, the stack will create an [AWS::S3::Bucket](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html) resource that is used to capture logs.
+
+By default, AWS Services do not have permission to perform actions on your instances. So, the stack will create an [AWS::IAM::Role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html) which grants AWS Systems Manager (SSM) and EC2 Image Builder the necessary permissions to build an image.
+
+The instance also needs access to the bucket created by the stack, so a policy is added to the newly created role that allows the instance to use ```s3:PutObject``` to save logs to the logging bucket.
+
+Then, an [AWS::IAM::InstanceProfile](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html) is created, which passes the instance role to the EC2 instance.
+
+An [AWS::ImageBuilder::InfrastructureConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html) resource is created, and the Instance Profile is specified as one of its parameters. This parameter tells EC2 Image Builder to use the specified profile with the EC2 instance during the build.
+
+Next, the stack will create an [AWS::ECR::Repository](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html) resource. This Amazon Elastic Container Registry (ECR) will hold the resulting container image.
+
+The [AWS::ImageBuilder::Component](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html) will download the compressed .NET web application from S3, and install it in the Docker image ready for use.
+
+The [AWS::ImageBuilder::ContainerRecipe](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-containerrecipe.html) ties together the Ubuntu 18.04 parent image, the .NET runtime, and the custom component. This example demonstrates using the Dockerfile template default settings, which provides variables for your parent image, environments, and components. These variables will be replaced with Image Builder generated scripts at build time.
+
+The resource [AWS::ImageBuilder::DistributionConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html) allows you to specify the name and description of your output container image and settings for tagging and sharing to a target ECR repository in a specific region.
+
+The [AWS::ImageBuilder::ImagePipeline](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html) creates an automation pipeline for your container image builds. The pipeline is associated with the container recipe and can also be associated with an infrastructure configuration and distribution configuration. You can also use a schedule to configure how often and when a pipeline will automatically create a new image. In this example, the pipeline is scheduled to run a build at 10:00AM Coordinated Universal Time (UTC), every day. The build will only run if dependent resources have been updated.
+
+## Walkthrough
+
+It takes approximately 20 minutes for the stack build to complete.
+
+This solution can be deployed using both the AWS Management Console or the Command Line Interface (CLI).
+
+Before deploying the stack, a .NET web application must first be created and uploaded to an S3 Bucket.
+
+### Creating the .NET web application
+
+First, install the latest .NET SDK from the [Download .NET 5.0](https://dotnet.microsoft.com/download/dotnet/5.0) website.
+
+Next, create a .NET web application. As this is a sample, we will not be using https, although that is recommended for production use.
+
+```shell
+dotnet new webApp -o sample-web-application --no-https
+cd sample-web-application
+```
+
+The ```Program.cs``` file needs to be updated to listen on all network interfaces. For example, the following addition will enable the application to listen on TCP/5000.
+
+In the `Program.cs` file, add ```webBuilder.UseUrls("http://*:5000");``` after the `UserStartup<>` line. The `CreateDefaultBuilder` should include content similar to this:
+
+```cs
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                    webBuilder.UseUrls("http://*:5000");
+                });
+```
+
+Next, the .NET application needs to be compiled for Ubuntu 18.04.
+
+```shell
+dotnet publish --configuration release -r ubuntu.18.04-x64 --self-contained
+```
+
+The compiled application should exist in the ```./bin/release/net5.0/ubuntu.18.04-x64/publish``` folder. The next step is to compress the files and upload them to an existing S3 Bucket. The following commands will create a ```.tar.gz``` file, and using the AWS CLI, upload it to an S3 Bucket. Note, the S3 Bucket name needs to be updated.
+
+```shell
+cd bin/release/net5.0/ubuntu.18.04-x64/publish
+tar -czf ~/sample-web-application.tar.gz .
+aws s3 cp sample-web-application.tar.gz s3://< Insert your bucket name here >/sample-web-application.tar.gz
+```
+
+Next, update the CloudFormation parameters .json file (```ubuntu-dotnet-web-application-pipeline.json```) with the S3 object used in the AWS CLI command.
+
+### Deploying the Stack
+
+#### AWS Management Console
+
+1. Upload the ```ubuntu-dotnet-web-application-pipeline.yml``` template to CloudFormation.
+2. Update the stack parameters as desired, ensuring the ```DotnetS3SourceTarFile``` parameter points to the S3 location used when uploading the .NET web application to S3.
+3. You will see a checkbox informing you that the stack creates IAM resources. Read and check the box.
+4. Wait for the stack to build.
+5. Once built, a new Image Builder pipeline will exist. You can view this in the Image Builder console, and optionally trigger a manual execution of the pipeline to start the first image creation.
+
+#### AWS CLI
+
+1. Ensure that your YAML template and JSON parameters file are located within your current directory.
+2. Modify the parameters in ```ubuntu-dotnet-web-application-pipeline.json``` as necessary.
+3. Run the following command from your terminal:
+
+```shell
+aws cloudformation create-stack \
+--stack-name sample-ubuntu-dotnet-web-application-pipeline \
+--template-body file://ubuntu-dotnet-web-application-pipeline.yml \
+--parameters file://ubuntu-dotnet-web-application-pipeline.json \
+--capabilities CAPABILITY_NAMED_IAM \
+--region us-east-1
+```
+
+### Creating the Image
+
+To create the container image, navigate to the EC2 Image Builder console, then select Image pipelines from the side navigation. Click to enter the newly created pipeline. Under the Actions menu, select "Run pipeline".
+
+## Troubleshooting
+
+While the stack is building, you will see an EC2 instance running. This is either the build or test instance. AWS Systems Manager (SSM) Automation will also run. You can observe this automation to see the steps EC2 Image Builder takes to build your image.
+
+If the stack fails, check the CloudFormation events. These events include a description of any failed resources.
+
+## Cleanup
+
+To delete the resources created by the stack:
+
+1. Delete the contents of the S3 bucket created by the stack (if the bucket is not empty, the stack deletion will fail). To keep the bucket, add a ```Retain``` deletion policy to the CloudFormation bucket resource. See [DeletionPolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) for more information.
+2. Delete the container image within your ECR repository created by the stack (if the repository is not empty, the stack deletion will fail).
+3. Delete the stack in the CloudFormation console, or by using the CLI/SDK.

--- a/CloudFormation/Docker/ubuntu-dotnet-web-application/ubuntu-dotnet-web-application-pipeline.json
+++ b/CloudFormation/Docker/ubuntu-dotnet-web-application/ubuntu-dotnet-web-application-pipeline.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ParameterKey": "CustomSubnetId",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "CustomSecurityGroupId",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "BuildInstanceType",
+    "ParameterValue": "t2.micro"
+  },
+  {
+    "ParameterKey": "TargetECRRepository",
+    "ParameterValue": "sample-repository"
+  },
+  {
+    "ParameterKey": "ImageTag",
+    "ParameterValue": "latest"
+  },
+  {
+    "ParameterKey": "ResourceName",
+    "ParameterValue": "UbuntuDotnetWebsite"
+  },
+  {
+    "ParameterKey": "ResourceVersion",
+    "ParameterValue": "1.0.0"
+  },
+  {
+    "ParameterKey": "DotnetS3SourceTarFile",
+    "ParameterValue": "s3://< Insert your bucket name here >/sample-web-application.tar.gz"
+  },
+  {
+    "ParameterKey": "DotnetBinaryName",
+    "ParameterValue": "sample-web-application"
+  },
+  {
+    "ParameterKey": "WebsiteName",
+    "ParameterValue": "SampleDotnetWebApplication"
+  }
+]

--- a/CloudFormation/Docker/ubuntu-dotnet-web-application/ubuntu-dotnet-web-application-pipeline.yml
+++ b/CloudFormation/Docker/ubuntu-dotnet-web-application/ubuntu-dotnet-web-application-pipeline.yml
@@ -1,0 +1,313 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >
+  This sample template creates AWS CloudFormation resources for an EC2 ImageBuilder pipeline that builds an Ubuntu 18.04 container image to host
+  a .NET web application, and publishes the image to the an Amazon Elastic Container Registry (ECR) repository. The pipeline, by default, is
+  scheduled to run a build at 10:00AM Coordinated Universal Time (UTC) every day. The build will only run if dependent resources have been updated.
+
+Parameters:
+  CustomSubnetId:
+    Type: String
+    Default: ""
+    Description: If you do not have a default VPC, or want to use a different VPC, specify the ID of a subnet in which to place the instance used to customize your EC2 container image. If not specified, a subnet from your default VPC will be used.
+
+  CustomSecurityGroupId:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: Required if you specified a custom subnet ID. Comma-delimited list of one or more IDs of security groups belonging to the VPC to associate with the instance used to customize your EC2 container image.
+
+  BuildInstanceType:
+    Type: CommaDelimitedList
+    Default: 't2.micro'
+    Description: Comma-delimited list of one or more instance types to select from when building the image. Image Builder will select a type based on availability. The supplied default is compatible with the AWS Free Tier.
+
+  TargetECRRepository:
+    Description: Name of the target ECR repository to push container image to
+    Type: String
+    Default: sample-repository
+
+  ImageTag:
+    Description: Tag for the output docker image.
+    Type: String
+    Default: latest
+
+  ResourceName:
+    Type: String
+    Default: UbuntuDotnetWebsite
+    Description: A name to use for all Image Builder resources
+
+  ResourceVersion:
+    Type: String
+    Default: '1.0.0'
+    Description: The version to use for Image Builder resources
+
+  DotnetS3SourceTarFile:
+    Type: String
+    Default: s3://awspearca-demo-us-west-2/powershell-summit-2021/hello-powershell-summit-ubuntu.tar.gz
+    Description: An S3 URI to a zip file containing a .NET web application. The web application must have been published for the `win-x64` runtime. For example, `dotnet publish --configuration release --runtime win-x64`
+
+  DotnetBinaryName:
+    Type: String
+    Default: 'hello-powershell-summit'
+    Description: The .NET binary file to execute. This file must exist within the root of the zip file referenced in `DotnetS3SourceTarFile`.
+
+  WebsiteName:
+    Type: String
+    Default: 'DotnetWebsiteDemo'
+    Description: The website name. This is used for local folder paths on the image, and is used for the Windows Service.
+
+Conditions:
+  UseCustomSubnetId: !Not [ !Equals [ !Ref CustomSubnetId, "" ] ]
+
+Resources:
+  # Create an S3 Bucket for logs.
+  # When deleting the stack, make sure to empty the bucket first.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html
+  ImageBuilderLogBucket:
+    Type: AWS::S3::Bucket
+    # If you want to delete the stack, but keep the bucket, set the DelectionPolicy to Retain.
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+    # DeletionPolicy: Retain
+
+  # This creates an ECR repository, where EC2 Image builder can push the container image to after creation.
+  # When deleting this stack, make sure to empty the repository first. Otherwise, you
+  # will experience a status of "DELETE_FAILED" in CloudFormation.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecr-repository.html
+  ECRRepository:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Ref TargetECRRepository
+      ImageScanningConfiguration:
+        ScanOnPush: 'true'
+
+  # By default, AWS Services do not have permission to perform actions on your instances. This grants
+  # AWS Systems Manager (SSM) and EC2 Image Builder the necessary permissions to build a container image.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
+  # https://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-setting-up.html
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Metadata:
+      Comment: Role to be used by EC2 instance during image build.
+    Properties:
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilderECRContainerBuilds'
+        # The S3 policy is used to download the zip file from the provided S3 URI.
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonS3ReadOnlyAccess'
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+        Version: '2012-10-17'
+      Path: /executionServiceEC2Role/
+
+  # Policy to allow the instance to write to the S3 bucket (via instance role / instance profile).
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html
+  InstanceRoleLoggingPolicy:
+    Type: AWS::IAM::Policy
+    Metadata:
+      Comment: Allows the instance to save log files to an S3 bucket.
+    Properties:
+      PolicyName: ImageBuilderLogBucketPolicy
+      Roles:
+        - Ref: InstanceRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - s3:PutObject
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::${ImageBuilderLogBucket}/*'
+
+  # To pass the InstanceRole to an EC2 instance, we need an InstanceProfile.
+  # This profile will be used during the image build process.
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /executionServiceEC2Role/
+      Roles:
+        - Ref: InstanceRole
+
+  # Specifies the infrastructure within which to build and test your image.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html
+  Infrastructure:
+    Type: AWS::ImageBuilder::InfrastructureConfiguration
+    Properties:
+      Name: !Ref ResourceName
+      Description: 'This infrastructure configuration will launch into our custom ImageBuilder VPC'
+      InstanceProfileName: !Ref InstanceProfile
+      # Set of one or more instance types to use when building the instance. Image Builder will select a type
+      # based on availability.
+      InstanceTypes:
+        !Ref BuildInstanceType
+      # Specify an S3 bucket and EC2 Image Builder will save logs to the bucket.
+      Logging:
+        S3Logs:
+          S3BucketName: !Ref ImageBuilderLogBucket
+          S3KeyPrefix: !Sub 'imagebuilder-${AWS::StackName}'
+      # If you would like to keep the instance running after a failed build, set TerminateInstanceOnFailure to false.
+      # TerminateInstanceOnFailure: false
+      # If you do not have a default VPC or want to use a different VPC, you must specify the IDs of a subnet and one or more
+      # security groups to be associated with the build instance.
+      SubnetId: !If [ UseCustomSubnetId, !Ref CustomSubnetId , !Ref 'AWS::NoValue' ]
+      SecurityGroupIds:
+        - !If [ UseCustomSubnetId, !Ref CustomSecurityGroupId , !Ref 'AWS::NoValue' ]
+
+  # This component will download the .NET web application from the provided S3 URI. The application will
+  # be extracted to disk and the execute bit set on the application.
+  # A startup `rc.local` script is not required as the dockerfile will specity the container's entry point.
+  Component:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: !Ref ResourceName
+      Version: !Ref ResourceVersion
+      Platform: Linux
+      Description: Downloads and installs a .NET web application.
+      ChangeDescription: 'Created with CloudFormation'
+      Data: !Sub |
+        schemaVersion: 1.0
+        constants:
+          - Source:
+              type: string
+              value: '${DotnetS3SourceTarFile}'
+          - DotnetBinaryName:
+              type: string
+              value: '${DotnetBinaryName}'
+          - WebsiteName:
+              type: string
+              value: '${WebsiteName}'
+        phases:
+          - name: build
+            steps:
+              - name: EnsureWebsiteFolderDoesNotExist
+                action: DeleteFolder
+                inputs:
+                  - path: '/{{ WebsiteName }}'
+                    force: true
+              - name: CreateWebsiteFolder
+                action: CreateFolder
+                inputs:
+                  - path: '/{{ WebsiteName }}'
+                    permissions: 0777
+              - name: TarFileName
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - 'source="{{ Source }}"'
+                    - echo ${!source##*/}
+              - name: DownloadTarFile
+                action: S3Download
+                inputs:
+                  - source: '{{ Source }}'
+                    destination: '/{{ WebsiteName }}/{{ build.TarFileName.outputs.stdout }}'
+              - name: ExtractWebsite
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - cd /{{ WebsiteName }}
+                    - tar zxvf /{{ WebsiteName }}/{{ build.TarFileName.outputs.stdout }}
+              - name: SetWebsiteExecutable
+                action: SetFilePermissions
+                inputs:
+                  - path: '/{{ WebsiteName }}/{{ DotnetBinaryName }}'
+                    permissions: 0755
+              - name: Cleanup
+                action: DeleteFile
+                inputs:
+                  - path: '/{{ WebsiteName }}/{{ build.TarFileName.outputs.stdout }}'
+
+  # Recipe which references the `ubuntu-18-x86-18-04` parent image. This also includes component references
+  # to ensure the container is updated, and installed the .NET runtime and the custom component.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-containerrecipe.html
+  Recipe:
+    Type: AWS::ImageBuilder::ContainerRecipe
+    Properties:
+      Name: !Ref ResourceName
+      Version: !Ref ResourceVersion
+      ParentImage: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/ubuntu-18-x86-18-04/x.x.x'
+      # When using a custom source image (e.g. from DockerHub), make sure to specify the appropriate operating system platfrom
+      # via the "PlatformOverride" property.
+      ContainerType: DOCKER
+      Components:
+        - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/update-linux/x.x.x'
+        - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/dotnet-runtime-linux/5.x.x'
+        - ComponentArn: !Ref Component
+      TargetRepository:
+        Service: ECR
+        RepositoryName: !Ref TargetECRRepository
+      # You can create your Dockerfile from scratch, or by using the Dockerfile template default settings.
+      # This example uses the template default settings, which provides variables for your parent image, environments, and components.
+      # These variables will be replaced with Image Builder generated scripts at build time.
+      # In this Dockerfile, `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` is required to run .NET, and the entrypoint
+      # is configured with the .NET application.
+      DockerfileTemplateData: !Sub |
+        FROM {{{ imagebuilder:parentImage }}}
+        ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
+        {{{ imagebuilder:environments }}}
+        {{{ imagebuilder:components }}}
+        CMD "/${WebsiteName}/${DotnetBinaryName}"
+      WorkingDirectory: /tmp
+
+  # A CloudWatch LogGroup that maps to where the image creation logs will be published.
+  # This ensures the retention is configured, and that the group is removed on stack deletion.
+  RecipeLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/imagebuilder/${ResourceName}'
+      RetentionInDays: 7
+
+  # Allows you to specify the name and description of your output container image and settings for tagging and sharing
+  # to a target ECR repository in a specific region.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html
+  Distribution:
+    Type: AWS::ImageBuilder::DistributionConfiguration
+    Properties:
+      Name: !Ref ResourceName
+      Description: 'This distribution configuration will deploy our container image to the desired target ECR repository in the current region'
+      Distributions:
+        - Region: !Ref 'AWS::Region'
+          ContainerDistributionConfiguration:
+            TargetRepository:
+              Service: ECR
+              RepositoryName: !Ref TargetECRRepository
+            # By default, if no container tags are specified, the "Image tags" value in ECR will reflect the image build version (e.g. 1.0.0-1),
+            # which can be found by navigating to EC2 ImageBuilder in the AWS Management Console.
+            ContainerTags:
+              - !Ref ImageTag
+
+  # The pipeline is scheduled to run a build at 10:00AM Coordinated Universal Time (UTC) every day.
+  # The build will only run if dependencies have been updated.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html
+  Pipeline:
+    Type: AWS::ImageBuilder::ImagePipeline
+    Properties:
+      ContainerRecipeArn: !Ref Recipe
+      Description: A pipeline to automate creation of the container
+      DistributionConfigurationArn: !Ref Distribution
+      ImageTestsConfiguration:
+        ImageTestsEnabled: false
+        TimeoutMinutes: 60
+      InfrastructureConfigurationArn: !Ref Infrastructure
+      Name: !Ref ResourceName
+      Schedule:
+        PipelineExecutionStartCondition: EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE
+        ScheduleExpression: 'cron(0 10 * * ? *)'
+      Status: ENABLED
+      Tags:
+        Purpose: PowerShellSummitContainerDemo
+
+Outputs:
+  # This export can be used to create ECS Task Definitions that reference the output image.
+  UbuntuDotnetWebsiteImage:
+    Value: !Sub '${AWS::AccountId}.dkr.ecr.${AWS::Region}.${AWS::URLSuffix}/${ECRRepository}:${ImageTag}'
+    Export:
+      Name: UbuntuDotnetWebsiteImage

--- a/CloudFormation/Windows/cascading-images-with-dotnet-web-application/README.md
+++ b/CloudFormation/Windows/cascading-images-with-dotnet-web-application/README.md
@@ -1,0 +1,145 @@
+# Windows cascading Image Pipeline for hosting a .NET web application
+
+This is a set of sample templates that demonstrate how to use EC2 Image Builder CloudFormation resources to build a set of cascading Windows images. The first image is a baseline image, while the second image is build from the first, and can host a .NET web application.
+
+***Internet connectivity is required in your default VPC*** to pull the source image by digest from a Docker Hub repository. If you do not have a default VPC, or want to use a custom VPC, you will need to specify a subnet ID and one or more security group IDs in the VPC as parameters when you create a stack based on this template.
+
+## How the Stacks Work
+
+### Stack 1: Windows Baseline Image
+
+This stack will create an image pipeline that outputs a baseline Windows Image.
+
+### Stack 2: Windows .NET Application Stack
+
+This stack will use the first image as it's source, and create a stack that can host a .NET Application.
+
+### Resources Contained in both Stacks
+
+Both stacks use a similar set of CloudFormation resources, with minor adjustments.
+
+First, both stacks will create an [AWS::S3::Bucket](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html) resource that is used to capture logs.
+
+By default, AWS Services do not have permission to perform actions on your instances. So, the stack will create an [AWS::IAM::Role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html) which grants AWS Systems Manager (SSM) and EC2 Image Builder the necessary permissions to build an image.
+
+The instance also needs access to the bucket created by the stack, so a policy is added to the newly created role that allows the instance to use ```s3:PutObject``` to save logs to the logging bucket.
+
+Then, an [AWS::IAM::InstanceProfile](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-instanceprofile.html) is created, which passes the instance role to the EC2 instance.
+
+An [AWS::ImageBuilder::InfrastructureConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html) resource is created, and the Instance Profile is specified as one of its parameters. This parameter tells EC2 Image Builder to use the specified profile with the EC2 instance during the build.
+
+The [AWS::ImageBuilder::ContainerRecipe](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-containerrecipe.html) ties together the Ubuntu 18.04 parent image, the .NET runtime, and the custom component. This example demonstrates using the Dockerfile template default settings, which provides variables for your parent image, environments, and components. These variables will be replaced with Image Builder generated scripts at build time.
+
+The resource [AWS::ImageBuilder::DistributionConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html) allows you to specify the name and description of your output container image and settings for tagging and sharing to a target ECR repository in a specific region.
+
+The [AWS::ImageBuilder::ImagePipeline](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html) creates an automation pipeline for your container image builds. The pipeline is associated with the container recipe and can also be associated with an infrastructure configuration and distribution configuration. You can also use a schedule to configure how often and when a pipeline will automatically create a new image. In this example, the pipeline is scheduled to run a build at 10:00AM Coordinated Universal Time (UTC), every day. The build will only run if dependent resources have been updated.
+
+As these stacks will export an Image ARN, the Image name must be converted to lowercase. A custom Lambda resource is used to do that. Therefore, an [AWS::Lambda::Function](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html) resource is created to convert an input parameter to lowercase. Related resources, including an [AWS::Logs::LogGroup](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-loggroup.html) resource and an [AWS::IAM::Role](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html) resource are created to allow the Lambda Function access to execution, and to control it's CloudWatch LogGroup.
+
+Next, the Lambda Function is executed using a [Cloudformation Custom Resource](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/template-custom-resources.html) (the *Custom::Lowercase* resource in the stacks).
+
+### Resources Specific to the .NET Application Stack
+
+Specific to the second stack are two [AWS::ImageBuilder::Component](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html) resources.
+
+The first installs NSSM, the [Non-Sucking Service Manager](https://nssm.cc/). This will be used to create a custom Windows Service for the .NET web application.
+
+The second will download the compressed .NET web application from S3, and install it ready for use.
+
+## Walkthrough
+
+It takes approximately 120-150 minutes to complete the walkthrough.
+
+This solution can be deployed using both the AWS Management Console or the Command Line Interface (CLI).
+
+Before deploying the stacks, a .NET web application must first be created and uploaded to an S3 Bucket.
+
+### Creating the .NET web application
+
+First, install the latest .NET SDK from the [Download .NET 5.0](https://dotnet.microsoft.com/download/dotnet/5.0) website.
+
+Next, create a .NET web application. As this is a sample, we will not be using https, although that is recommended for production use.
+
+```shell
+dotnet new webApp -o sample-web-application --no-https
+cd sample-web-application
+```
+
+The ```Program.cs``` file needs to be updated to listen on all network interfaces. For example, the following addition will enable the application to listen on TCP/5000.
+
+In the `Program.cs` file, add ```webBuilder.UseUrls("http://*:5000");``` after the `UserStartup<>` line. The `CreateDefaultBuilder` should include content similar to this:
+
+```cs
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                    webBuilder.UseUrls("http://*:5000");
+                });
+```
+
+Next, the .NET application needs to be compiled for Windows.
+
+```shell
+dotnet publish --configuration release --runtime win-x64
+```
+
+The compiled application should exist in the ```./bin/release/net5.0/win-x64/publish``` folder. The next step is to compress the files and upload them to an existing S3 Bucket. The following commands will create a ```.zip``` file, and using the AWS CLI, upload it to an S3 Bucket. Note, the S3 Bucket name needs to be updated.
+
+```shell
+cd bin/release/net5.0/win-x64/publish
+zip -r ~/sample-web-application.zip .
+aws s3 cp ~/sample-web-application.zip s3://< Insert your bucket name here >/sample-web-application.zip
+```
+
+Next, update the CloudFormation parameters .json file (```windows-dotnet-application-stack.json```) with the S3 object used in the AWS CLI command.
+
+### Deploying the Stacks
+
+To deploy each of the stacks, starting with the baseline stack, the follow instructions can be followed.
+
+After deploying the baseline stack, the pipeline must be executed to create the baseline image before deploying the second stack.
+
+#### AWS Management Console
+
+**Note:** Replace ```windows-baseline-stack``` with ```windows-dotnet-application-stack``` when deploying the .NET application stack.
+
+1. Upload the ```windows-baseline-stack.yml``` template to CloudFormation.
+2. Update the stack parameters as desired, ensuring the ```DotnetS3SourceTarFile``` parameter in the second stack points to the S3 location used when uploading the .NET web application to S3.
+3. You will see a checkbox informing you that the stack creates IAM resources. Read and check the box.
+4. Wait for the stack to build.
+5. Once built, a new Image Builder pipeline will exist. You can view this in the Image Builder console, and optionally trigger a manual execution of the pipeline to start the first image creation.
+
+#### AWS CLI
+
+**Note:** Replace ```windows-baseline-stack``` with ```windows-dotnet-application-stack``` when deploying the .NET application stack.
+
+1. Ensure that your YAML template and JSON parameters file are located within your current directory.
+2. Modify the parameters in ```windows-baseline-stack.json``` as necessary.
+3. Run the following command from your terminal:
+
+```shell
+aws cloudformation create-stack \
+--stack-name sample-windows-baseline-stack \
+--template-body file://windows-baseline-stack.yml \
+--parameters file://windows-baseline-stack.json \
+--capabilities CAPABILITY_NAMED_IAM \
+--region us-east-1
+```
+
+### Creating the Images
+
+To create the images, after deploying the stacks, navigate to the EC2 Image Builder console, then select Image pipelines from the side navigation. Click to enter the newly created pipeline. Under the Actions menu, select "Run pipeline".
+
+## Troubleshooting
+
+While the stack is building, you will see an EC2 instance running. This is either the build or test instance. AWS Systems Manager (SSM) Automation will also run. You can observe this automation to see the steps EC2 Image Builder takes to build your image.
+
+If the stack fails, check the CloudFormation events. These events include a description of any failed resources.
+
+## Cleanup
+
+To delete the resources created by the stack:
+
+1. Delete the contents of the S3 bucket created by the stack (if the bucket is not empty, the stack deletion will fail). To keep the bucket, add a ```Retain``` deletion policy to the CloudFormation bucket resource. See [DeletionPolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) for more information.
+2. Delete the container image within your ECR repository created by the stack (if the repository is not empty, the stack deletion will fail).
+3. Delete the stack in the CloudFormation console, or by using the CLI/SDK.

--- a/CloudFormation/Windows/cascading-images-with-dotnet-web-application/windows-baseline-stack.json
+++ b/CloudFormation/Windows/cascading-images-with-dotnet-web-application/windows-baseline-stack.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "CustomSubnetId",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "CustomSecurityGroupId",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "ResourceName",
+    "ParameterValue": "WindowsBaseline"
+  },
+  {
+    "ParameterKey": "ResourceVersion",
+    "ParameterValue": "1.0.0"
+  }
+]

--- a/CloudFormation/Windows/cascading-images-with-dotnet-web-application/windows-baseline-stack.yml
+++ b/CloudFormation/Windows/cascading-images-with-dotnet-web-application/windows-baseline-stack.yml
@@ -1,0 +1,258 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >
+  This sample template creates AWS CloudFormation resources for an EC2 ImageBuilder pipeline that builds a baseline Windows Server Core 2019 image. The pipeline, by default, is scheduled to run a build at 8:00AM Coordinated Universal Time (UTC) daily. The build will only run if dependent resources have been updated.
+
+Parameters:
+  CustomSubnetId:
+    Type: String
+    Default: ""
+    Description: If you do not have a default VPC, or want to use a different VPC, specify the ID of a subnet in which to place the instance used to customize your EC2 container image. If not specified, a subnet from your default VPC will be used.
+
+  CustomSecurityGroupId:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: Required if you specified a custom subnet ID. Comma-delimited list of one or more IDs of security groups belonging to the VPC to associate with the instance used to customize your EC2 container image.
+
+  ResourceName:
+    Type: String
+    Default: WindowsBaseline
+    Description: A name to use for all Image Builder resources
+
+  ResourceVersion:
+    Type: String
+    Default: '1.0.0'
+    Description: The version to use for Image Builder resources
+
+Conditions:
+  UseCustomSubnetId: !Not [ !Equals [ !Ref CustomSubnetId, "" ] ]
+
+Resources:
+  # Create an S3 Bucket for logs.
+  # When deleting the stack, make sure to empty the bucket first.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html
+  ImageBuilderLogBucket:
+    Type: AWS::S3::Bucket
+    # If you want to delete the stack, but keep the bucket, set the DelectionPolicy to Retain.
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+    # DeletionPolicy: Retain
+
+  # By default, AWS Services do not have permission to perform actions on your instances. This grants
+  # AWS Systems Manager (SSM) and EC2 Image Builder the necessary permissions to build an image.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
+  # https://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-setting-up.html
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Metadata:
+      Comment: Role to be used by EC2 instance during image build.
+    Properties:
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+        Version: '2012-10-17'
+      Path: /executionServiceEC2Role/
+
+  # Policy to allow the instance to write to the S3 bucket (via instance role / instance profile).
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html
+  InstanceRoleLoggingPolicy:
+    Type: AWS::IAM::Policy
+    Metadata:
+      Comment: Allows the instance to save log files to an S3 bucket.
+    Properties:
+      PolicyName: ImageBuilderLogBucketPolicy
+      Roles:
+        - Ref: InstanceRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - s3:PutObject
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::${ImageBuilderLogBucket}/*'
+
+  # To pass the InstanceRole to an EC2 instance, we need an InstanceProfile.
+  # This profile will be used during the image build process.
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /executionServiceEC2Role/
+      Roles:
+        - Ref: InstanceRole
+
+  # Specifies the infrastructure within which to build and test your image.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html
+  Infrastructure:
+    Type: AWS::ImageBuilder::InfrastructureConfiguration
+    Properties:
+      Name: !Ref ResourceName
+      Description: 'This infrastructure configuration will launch into the CloudFormation parameter provided VPC.'
+      InstanceProfileName: !Ref InstanceProfile
+      # Specify an S3 bucket and EC2 Image Builder will save logs to the bucket.
+      Logging:
+        S3Logs:
+          S3BucketName: !Ref ImageBuilderLogBucket
+          S3KeyPrefix: !Sub 'imagebuilder-${AWS::StackName}'
+      # If you would like to keep the instance running after a failed build, set TerminateInstanceOnFailure to false.
+      # TerminateInstanceOnFailure: false
+      # If you do not have a default VPC or want to use a different VPC, you must specify the IDs of a subnet and one or more
+      # security groups to be associated with the build instance.
+      SubnetId: !If [ UseCustomSubnetId, !Ref CustomSubnetId , !Ref 'AWS::NoValue' ]
+      SecurityGroupIds:
+        - !If [ UseCustomSubnetId, !Ref CustomSecurityGroupId , !Ref 'AWS::NoValue' ]
+      Tags:
+        Purpose: ImageBuilderSample
+
+  # Recipe which references the latest Windows Server 2019 image, and includes a list of AWS managed quick-start components.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html
+  Recipe:
+    Type: AWS::ImageBuilder::ImageRecipe
+    Properties:
+      Name: !Ref ResourceName
+      Version: !Ref ResourceVersion
+      Components:
+        - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/update-windows/x.x.x'
+        - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/aws-cli-version-2-windows/x.x.x'
+        - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/powershell-windows/x.x.x'
+        - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/windows-activation-test/x.x.x'
+        - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/reboot-test-windows/x.x.x'
+      ParentImage: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/windows-server-2019-english-full-base-x86/x.x.x'
+      Tags:
+        Purpose: ImageBuilderSample
+      WorkingDirectory: 'C:\'
+
+  # A CloudWatch LogGroup that maps to where the image creation logs will be published.
+  # This ensures the retention is configured, and that the group is removed on stack deletion.
+  RecipeLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/imagebuilder/${ResourceName}'
+      RetentionInDays: 7
+
+  # The Distribution Configuration allows you to specify naming conventions and the account and region distributions of a successful image build.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html
+  Distribution:
+    Type: AWS::ImageBuilder::DistributionConfiguration
+    Properties:
+      Name: !Ref ResourceName
+      Description: !Sub 'Deploys the ${ResourceName} AMI to all desired regions.'
+      Distributions:
+        - Region: !Ref 'AWS::Region'
+          AmiDistributionConfiguration:
+            Name: !Sub '${ResourceName}-{{ imagebuilder:buildDate }}'
+            AmiTags:
+              Name: !Ref ResourceName
+      Tags:
+        Purpose: ImageBuilderSample
+
+  # In this example, the pipeline is scheduled to run a build at 8:00AM Coordinated Universal Time (UTC) every day.
+  # The build will only run if dependencies have been updated.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html
+  Pipeline:
+    Type: AWS::ImageBuilder::ImagePipeline
+    Properties:
+      Description: !Sub 'A pipeline to automate creation of the ${ResourceName} image'
+      DistributionConfigurationArn: !Ref Distribution
+      ImageRecipeArn: !Ref Recipe
+      ImageTestsConfiguration:
+        ImageTestsEnabled: true
+        TimeoutMinutes: 60
+      InfrastructureConfigurationArn: !Ref Infrastructure
+      Name: !Ref ResourceName
+      Schedule:
+        PipelineExecutionStartCondition: EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE
+        ScheduleExpression: 'cron(0 8 * * ? *)'
+      Status: ENABLED
+      Tags:
+        Purpose: ImageBuilderSample
+
+  # A CloudFormation export is used to allow future stacks to use the output image from this stack.
+  # As an Image ARN uses lowercase names, we will use a custom Lambda Function to transform the
+  # name to lowercase.
+  LowerCaseLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Returns the lowercase version of a string
+      MemorySize: 256
+      Runtime: python3.8
+      Handler: index.lambda_handler
+      Role: !GetAtt LowerCaseLambdaRole.Arn
+      Timeout: 30
+      Code:
+        ZipFile: |
+          import cfnresponse
+
+          def lambda_handler(event, context):
+              output = event['ResourceProperties'].get('InputString', '').lower()
+              responseData = {'OutputString': output}
+              cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+
+  # The CloudWatch Log Group for the Lambda Function.
+  RecipeLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${LowerCaseLambda}'
+      RetentionInDays: 3
+
+  # The IAM Role for the Lambda Function
+  LowerCaseLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: lambda-write-logs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*
+
+  # Invokes the Lambda Function to ensure a lowercase resource name is available.
+  LowerCaseImageName:
+    Type: Custom::Lowercase
+    DependsOn:
+      - RecipeLogGroup
+    Properties:
+      ServiceToken: !GetAtt LowerCaseLambda.Arn
+      InputString: !Ref ResourceName
+
+Outputs:
+  # The EC2 Image Builder Image ARN. For use in future stacks that will build cascading images with this image as their source.
+  WindowsBaselineImage:
+    Value: !Join
+      - ''
+      - - 'arn:'
+        - !Ref AWS::Partition
+        - ':imagebuilder:'
+        - !Ref AWS::Region
+        - ':'
+        - !Ref AWS::AccountId
+        - ':image/'
+        - !GetAtt LowerCaseImageName.OutputString
+        - '/x.x.x'
+    Export:
+      Name: WindowsBaselineImage

--- a/CloudFormation/Windows/cascading-images-with-dotnet-web-application/windows-dotnet-application-stack.json
+++ b/CloudFormation/Windows/cascading-images-with-dotnet-web-application/windows-dotnet-application-stack.json
@@ -1,0 +1,38 @@
+[
+  {
+    "ParameterKey": "CustomSubnetId",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "CustomSecurityGroupId",
+    "ParameterValue": ""
+  },
+  {
+    "ParameterKey": "ResourceName",
+    "ParameterValue": "WindowsDotnetWebsite"
+  },
+  {
+    "ParameterKey": "ResourceVersion",
+    "ParameterValue": "1.0.0"
+  },
+  {
+    "ParameterKey": "DotnetS3SourceZipFile",
+    "ParameterValue": "s3://< Insert your bucket name here >/sample-web-application.zip"
+  },
+  {
+    "ParameterKey": "DotnetBinaryName",
+    "ParameterValue": "sample-web-application"
+  },
+  {
+    "ParameterKey": "TCPPort",
+    "ParameterValue": "5000"
+  },
+  {
+    "ParameterKey": "WebsiteName",
+    "ParameterValue": "SampleDotnetWebApplication"
+  },
+  {
+    "ParameterKey": "HTMLTitleValidationString",
+    "ParameterValue": "Home page - sample_web_application"
+  }
+]

--- a/CloudFormation/Windows/cascading-images-with-dotnet-web-application/windows-dotnet-application-stack.yml
+++ b/CloudFormation/Windows/cascading-images-with-dotnet-web-application/windows-dotnet-application-stack.yml
@@ -1,0 +1,518 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >
+  This sample template creates AWS CloudFormation resources for an EC2 ImageBuilder pipeline that builds a Windows Server 2019 image running a .NET web application. The pipeline, by default, is scheduled to run a build at 10:00AM Coordinated Universal Time (UTC) daily. The build will only run if dependent resources have been updated.
+
+Parameters:
+  CustomSubnetId:
+    Type: String
+    Default: ""
+    Description: If you do not have a default VPC, or want to use a different VPC, specify the ID of a subnet in which to place the instance used to customize your EC2 container image. If not specified, a subnet from your default VPC will be used.
+
+  CustomSecurityGroupId:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: Required if you specified a custom subnet ID. Comma-delimited list of one or more IDs of security groups belonging to the VPC to associate with the instance used to customize your EC2 container image.
+
+  ResourceName:
+    Type: String
+    Default: DotnetWebsite
+    Description: A name to use for all Image Builder resources
+
+  ResourceVersion:
+    Type: String
+    Default: '1.0.0'
+    Description: The version to use for Image Builder resources
+
+  DotnetS3SourceZipFile:
+    Type: String
+    Description: An S3 URI to a zip file containing a .NET web application. The web application must have been published for the `win-x64` runtime. For example, `dotnet publish --configuration release --runtime win-x64`
+
+  DotnetBinaryName:
+    Type: String
+    Default: 'hellosample-web-application.exe'
+    Description: The .NET binary file to execute. This file must exist within the root of the zip file referenced in `DotnetS3SourceZipFile`.
+
+  TCPPort:
+    Type: String
+    Default: '5000'
+    Description: The TCP Port for the .NET web application. This should match the port configured in the .NET web application.
+
+  WebsiteName:
+    Type: String
+    Default: 'DotnetWebsiteDemo'
+    Description: The website name. This is used for local folder paths on the image, and is used for the Windows Service.
+
+  HTMLTitleValidationString:
+    Type: String
+    Default: 'Home page - hello_powershell_summit'
+    Description: A string that should exist between the HTML <Title> and </Title> tags. This string is used for validating the website is available.
+
+Conditions:
+  UseCustomSubnetId: !Not [ !Equals [ !Ref CustomSubnetId, "" ] ]
+
+Resources:
+  # Create an S3 Bucket for logs.
+  # When deleting the stack, make sure to empty the bucket first.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-s3-bucket.html
+  ImageBuilderLogBucket:
+    Type: AWS::S3::Bucket
+    # If you want to delete the stack, but keep the bucket, set the DelectionPolicy to Retain.
+    # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html
+    # DeletionPolicy: Retain
+
+  # By default, AWS Services do not have permission to perform actions on your instances. This grants
+  # AWS Systems Manager (SSM) and EC2 Image Builder the necessary permissions to build a container image.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html
+  # https://docs.aws.amazon.com/imagebuilder/latest/userguide/image-builder-setting-up.html
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Metadata:
+      Comment: Role to be used by EC2 instance during image build.
+    Properties:
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+        # The S3 policy is used to download the zip file from the provided S3 URI.
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonS3ReadOnlyAccess'
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+        Version: '2012-10-17'
+      Path: /executionServiceEC2Role/
+
+  # Policy to allow the instance to write to the S3 bucket (via instance role / instance profile).
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-policy.html
+  InstanceRoleLoggingPolicy:
+    Type: AWS::IAM::Policy
+    Metadata:
+      Comment: Allows the instance to save log files to an S3 bucket.
+    Properties:
+      PolicyName: ImageBuilderLogBucketPolicy
+      Roles:
+        - Ref: InstanceRole
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - s3:PutObject
+            Effect: Allow
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::${ImageBuilderLogBucket}/*'
+
+  # To pass the InstanceRole to an EC2 instance, we need an InstanceProfile.
+  # This profile will be used during the image build process.
+  # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /executionServiceEC2Role/
+      Roles:
+        - Ref: InstanceRole
+
+  # Specifies the infrastructure within which to build and test your image.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html
+  Infrastructure:
+    Type: AWS::ImageBuilder::InfrastructureConfiguration
+    Properties:
+      Name: !Ref ResourceName
+      Description: 'This infrastructure configuration will launch into the CloudFormation parameter provided VPC.'
+      InstanceProfileName: !Ref InstanceProfile
+      # Specify an S3 bucket and EC2 Image Builder will save logs to the bucket.
+      Logging:
+        S3Logs:
+          S3BucketName: !Ref ImageBuilderLogBucket
+          S3KeyPrefix: !Sub 'imagebuilder-${AWS::StackName}'
+      # If you would like to keep the instance running after a failed build, set TerminateInstanceOnFailure to false.
+      # TerminateInstanceOnFailure: false
+      # If you do not have a default VPC or want to use a different VPC, you must specify the IDs of a subnet and one or more
+      # security groups to be associated with the build instance.
+      SubnetId: !If [ UseCustomSubnetId, !Ref CustomSubnetId , !Ref 'AWS::NoValue' ]
+      SecurityGroupIds:
+        - !If [ UseCustomSubnetId, !Ref CustomSecurityGroupId , !Ref 'AWS::NoValue' ]
+      Tags:
+        Purpose: ImageBuilderSample
+
+  # This sample will install the .NET web application as a Windows service. NSSM is a common utility used
+  # to install custom applications as a Windows service. This component will download and install NSSM. It
+  # will also update the `Path` environment variable.
+  NSSMInstallationComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: !Sub '${ResourceName}-NSSM'
+      Version: !Ref ResourceVersion
+      Platform: Windows
+      Description: NSSM can be used to create a custom Windows Service. This component will download and install NSSM. The `Path` environment variable will also be updated.
+      ChangeDescription: 'Created with CloudFormation'
+      Data: !Sub |
+        schemaVersion: 1.0
+        constants:
+          - Application:
+              type: string
+              value: NSSM
+          - Source:
+              type: string
+              value: https://nssm.cc/release/nssm-2.24.zip
+        phases:
+          - name: build
+            steps:
+              - name: ZipFile
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - $filename = '{{ Source }}'.split('/')[-1]
+                    - Join-Path -Path $env:TEMP -ChildPath $filename
+              - name: TemporaryPath
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - Join-Path -Path $env:TEMP -ChildPath '{{ Application }}'
+              - name: InstallPath
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - Join-Path -Path $env:ProgramFiles -ChildPath '{{ Application }}'
+              - name: DownloadNSSM
+                action: WebDownload
+                inputs:
+                  - source: '{{ Source }}'
+                    destination: '{{ build.ZipFile.outputs.stdout }}'
+                    overwrite: true
+              - name: ExtractNSSMZipFile
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - $ErrorActionPreference = 'Stop'
+                    - $ProgressPreference = 'SilentlyContinue'
+                    - Write-Host "Extracting '{{ build.ZipFile.outputs.stdout }}' to '{{ build.TemporaryPath.outputs.stdout }}'..."
+                    - Expand-Archive -Path '{{ build.ZipFile.outputs.stdout }}' -DestinationPath '{{ build.TemporaryPath.outputs.stdout }}' -Force
+              - name: NSSMExtractedSource
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - $ErrorActionPreference = 'Stop'
+                    - (Get-ChildItem -Path '{{ build.TemporaryPath.outputs.stdout }}' | Where-Object {$_.Name -like 'nssm*'} | Select-Object -First 1).FullName
+              - name: MoveSourceToDesiredInstallationFolder
+                action: MoveFolder
+                inputs:
+                  - source: '{{ build.NSSMExtractedSource.outputs.stdout }}'
+                    destination: '{{ build.InstallPath.outputs.stdout }}'
+                    overwrite: true
+              - name: UpdatePath
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - |
+                      $ErrorActionPreference = 'Stop'
+                      $currentPath = [Environment]::GetEnvironmentVariable('Path', [EnvironmentVariableTarget]::Machine)
+                      $separator = [System.IO.Path]::PathSeparator
+                      $addition = 'C:\Program Files\NSSM\win64'
+                      $newPath = '{0}{1}{2}' -f $currentPath, $separator, $addition
+                      [Environment]::SetEnvironmentVariable('Path', $newPath, [EnvironmentVariableTarget]::Machine)
+              - name: RebootForPathUpdate
+                action: Reboot
+
+  # This component will download the .NET web application from the provided S3 URI. The application will
+  # be extracted to disk, and installed as a Windows service using NSSM.
+  WebsiteInstallationComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: !Sub '${ResourceName}-Website-Installation'
+      Version: !Ref ResourceVersion
+      Platform: Windows
+      Description: Downloads and installs a .NET web application as a Windows Service using NSSM.
+      ChangeDescription: 'Created with CloudFormation'
+      Data: !Sub |
+        schemaVersion: 1.0
+        constants:
+          - Source:
+              type: string
+              value: '${DotnetS3SourceZipFile}'
+          - DotnetBinaryName:
+              type: string
+              value: '${DotnetBinaryName}'
+          - WebsiteName:
+              type: string
+              value: '${WebsiteName}'
+          - TCPPort:
+              type: string
+              value: '${TCPPort}'
+          - HTMLTitleValidationString:
+              type: string
+              value: '${HTMLTitleValidationString}'
+        phases:
+          - name: build
+            steps:
+              - name: WebsitePath
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - Write-Host "$env:SystemDrive\{{ WebsiteName }}"
+              - name: ZipFile
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - $filename = '{{ Source }}'.split('/')[-1]
+                    - Join-Path -Path $env:TEMP -ChildPath $filename
+              - name: DownloadZipFile
+                action: S3Download
+                inputs:
+                  - source: '{{ Source }}'
+                    destination: '{{ build.ZipFile.outputs.stdout }}'
+              - name: EnsureWebsiteFolderDoesNotExist
+                action: DeleteFolder
+                inputs:
+                  - path: '{{ build.WebsitePath.outputs.stdout }}'
+                    force: true
+              - name: CreateWebsiteFolder
+                action: CreateFolder
+                inputs:
+                  - path: '{{ build.WebsitePath.outputs.stdout }}'
+              - name: ExtractWebsite
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - $ErrorActionPreference = 'Stop'
+                    - $ProgressPreference = 'SilentlyContinue'
+                    - Write-Host "Extracting '{{ build.ZipFile.outputs.stdout }}' to '{{ build.WebsitePath.outputs.stdout }}'..."
+                    - Expand-Archive -Path '{{ build.ZipFile.outputs.stdout }}' -DestinationPath '{{ build.WebsitePath.outputs.stdout }}'
+              - name: CreateWindowsService
+                action: ExecuteBinary
+                inputs:
+                  path: nssm.exe
+                  arguments:
+                    - 'install'
+                    - '{{ WebsiteName }}'
+                    - '{{ build.WebsitePath.outputs.stdout }}\{{ DotnetBinaryName }}'
+              - name: SetServiceStartupDirectory
+                action: ExecuteBinary
+                inputs:
+                  path: nssm.exe
+                  arguments:
+                    - 'set'
+                    - '{{ WebsiteName }}'
+                    - 'AppDirectory'
+                    - '{{ build.WebsitePath.outputs.stdout }}'
+              - name: CreateFirewallRule
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - |
+                      $ErrorActionPreference = 'Stop'
+                      if (Get-NetFirewallRule -Name '{{ WebsiteName }}' -ErrorAction SilentlyContinue) {
+                          Write-Host 'The firewall rule allowing inbound TCP/{{ TCPPort }} traffic already exists.'
+                      } else {
+                          Write-Host 'Creating a firewall rule allowing inbound TCP/{{ TCPPort }} traffic'
+                          $newNetFirewallRule = @{
+                              Name = '{{ WebsiteName }}'
+                              DisplayName = '{{ WebsiteName }}'
+                              Description = 'Allows inbound traffic for the {{ WebsiteName }} website'
+                              Enabled = 'true' # This must be a string, not a bool.
+                              Profile = 'Any'
+                              Direction = 'Inbound'
+                              Action = 'Allow'
+                              Protocol = 'TCP'
+                              LocalPort = '{{ TCPPort }}'
+                              ErrorAction = 'SilentlyContinue'
+                          }
+                          New-NetFirewallRule @newNetFirewallRule
+                      }
+              - name: StartService
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - $ErrorActionPreference = 'Stop'
+                    - Start-Service -Name '{{ WebsiteName }}'
+              - name: CleanupZipFiles
+                action: DeleteFile
+                inputs:
+                  - path: '{{ build.ZipFile.outputs.stdout }}'
+
+          - name: validate
+            steps:
+              - name: TestWebsite
+                action: ExecutePowerShell
+                maxAttempts: 3
+                inputs:
+                  commands:
+                    - |
+                      $ErrorActionPreference = 'Stop'
+                      try {
+                          $content = (Invoke-WebRequest -uri http://localhost:{{ TCPPort }} -UseBasicParsing).content
+                          if ($content -like '*<title>{{ HTMLTitleValidationString }}</ title>*') {
+                              Write-Host 'The website is responding on TCP/{{ TCPPort }}'
+                          } else {
+                              throw 'The website is not responding on TCP/{{ TCPPort }}. Failed validation.'
+                          }
+                      } catch {
+                          # Something failed. Sleep before allowing retry
+                          Start-Sleep -Seconds 15
+                      }
+
+          - name: test
+            steps:
+              - name: TestWebsite
+                action: ExecutePowerShell
+                maxAttempts: 3
+                inputs:
+                  commands:
+                    - |
+                      $ErrorActionPreference = 'Stop'
+                      try {
+                          $content = (Invoke-WebRequest -uri http://localhost:{{ TCPPort }} -UseBasicParsing).content
+                          if ($content -like '*<title>{{ HTMLTitleValidationString }}</ title>*') {
+                              Write-Host 'The website is responding on TCP/{{ TCPPort }}'
+                          } else {
+                              throw 'The website is not responding on TCP/{{ TCPPort }}. Failed validation.'
+                          }
+                      } catch {
+                          # Something failed. Sleep before allowing retry
+                          Start-Sleep -Seconds 15
+                      }
+
+  # Recipe which references Windows Baseline image built using the CloudFormation exported Image ARN from the `WindowsBaselineStack`.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html
+  Recipe:
+    Type: AWS::ImageBuilder::ImageRecipe
+    Properties:
+      Name: !Ref ResourceName
+      Version: !Ref ResourceVersion
+      Components:
+        - ComponentArn: !Ref NSSMInstallationComponent
+        - ComponentArn: !Ref WebsiteInstallationComponent
+      ParentImage: !ImportValue WindowsBaselineImage
+      Tags:
+        Purpose: ImageBuilderSample
+      WorkingDirectory: 'C:\'
+
+  # A CloudWatch LogGroup that maps to where the image creation logs will be published.
+  # This ensures the retention is configured, and that the group is removed on stack deletion.
+  RecipeLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/imagebuilder/${ResourceName}'
+      RetentionInDays: 7
+
+  # The Distribution Configuration allows you to specify naming conventions and the account and region distributions of a successful image build.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-distributionconfiguration.html
+  Distribution:
+    Type: AWS::ImageBuilder::DistributionConfiguration
+    Properties:
+      Name: !Ref ResourceName
+      Description: !Sub 'Deploys the ${ResourceName} AMI to all desired regions.'
+      Distributions:
+        - Region: !Ref 'AWS::Region'
+          AmiDistributionConfiguration:
+            Name: !Sub '${ResourceName}-{{ imagebuilder:buildDate }}'
+            AmiTags:
+              Name: !Ref ResourceName
+      Tags:
+        Purpose: ImageBuilderSample
+
+  # The pipeline is scheduled to run a build at 10:00AM Coordinated Universal Time (UTC) every day.
+  # The build will only run if dependencies have been updated.
+  # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagepipeline.html
+  Pipeline:
+    Type: AWS::ImageBuilder::ImagePipeline
+    Properties:
+      Description: !Sub 'A pipeline to automate creation of the ${ResourceName} image'
+      DistributionConfigurationArn: !Ref Distribution
+      ImageRecipeArn: !Ref Recipe
+      ImageTestsConfiguration:
+        ImageTestsEnabled: true
+        TimeoutMinutes: 60
+      InfrastructureConfigurationArn: !Ref Infrastructure
+      Name: !Sub '${ResourceName}'
+      Schedule:
+        PipelineExecutionStartCondition: EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE
+        ScheduleExpression: 'cron(0 10 * * ? *)'
+      Status: ENABLED
+      Tags:
+        Purpose: ImageBuilderSample
+
+  # A CloudFormation export is used to allow future stacks to use the output image from this stack.
+  # As an Image ARN uses lowercase names, we will use a custom Lambda Function to transform the
+  # name to lowercase.
+  LowerCaseLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Returns the lowercase version of a string
+      MemorySize: 256
+      Runtime: python3.8
+      Handler: index.lambda_handler
+      Role: !GetAtt LowerCaseLambdaRole.Arn
+      Timeout: 30
+      Code:
+        ZipFile: |
+          import cfnresponse
+
+          def lambda_handler(event, context):
+              output = event['ResourceProperties'].get('InputString', '').lower()
+              responseData = {'OutputString': output}
+              cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData)
+
+  # The CloudWatch Log Group for the Lambda Function.
+  RecipeLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub '/aws/lambda/${LowerCaseLambda}'
+      RetentionInDays: 3
+
+  # The IAM Role for the Lambda Function
+  LowerCaseLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: lambda-write-logs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: "Allow"
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*
+
+  # Invokes the Lambda Function to ensure a lowercase resource name is available.
+  LowerCaseImageName:
+    Type: Custom::Lowercase
+    DependsOn:
+      - RecipeLogGroup
+    Properties:
+      ServiceToken: !GetAtt LowerCaseLambda.Arn
+      InputString: !Ref ResourceName
+
+Outputs:
+  # The EC2 Image Builder Image ARN. For use in future stacks that will build cascading images with this image as their source.
+  DotnetWebsiteImage:
+    Value: !Join
+      - ''
+      - - 'arn:'
+        - !Ref AWS::Partition
+        - ':imagebuilder:'
+        - !Ref AWS::Region
+        - ':'
+        - !Ref AWS::AccountId
+        - ':image/'
+        - !GetAtt LowerCaseImageName.OutputString
+        - '/x.x.x'
+    Export:
+      Name: DotnetWebsiteImage


### PR DESCRIPTION
*Description of changes:*

This provides two sets of .NET focused samples.

1. CloudFormation template for demonstrating an Ubuntu container image that hosts a .NET web application.
2. A set of CloudFormation templates for demonstrating cascading Windows images, where the first is a baseline image, and the second builds from the baseline and hosts a .NET web application.

These samples were used in the PowerShell and DevOps Global Summit 2021 presentation (that will be made public ~6 months after the event has finished).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
