### PR TITLE
Update amazon-linux-2-container-image.json

### DIFF
--- a/CloudFormation/Docker/amazon-linux-2-with-helloworld/amazon-linux-2-container-image.json
+++ b/CloudFormation/Docker/amazon-linux-2-with-helloworld/amazon-linux-2-container-image.json
@@ -12,7 +12,7 @@
       "ParameterValue": "t2.micro"
     },
     {
-      "ParameterKey": "TargetECRRepositoryName",
+      "ParameterKey": "TargetECRRepository",
       "ParameterValue": "sample-repository"
     }
   ]


### PR DESCRIPTION
Rename ParameterKey TargetECRRepositoryName to TargetECRRepository. The CloudFormation template uses TargetECRRepository for the parameter name.

*Issue #, if available:* 18

*Description of changes:* Updated the ECR parameter key to match the CF template key


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
