### PR TITLE
Updated the .NET 5 Preview to .NET 6 Preview.

### DIFF
--- a/CloudFormation/Linux/ubuntu-with-net6/README.md
+++ b/CloudFormation/Linux/ubuntu-with-net6/README.md
@@ -1,10 +1,10 @@
-# Ubuntu Server 20 Image with .NET 5 Preview
+# Ubuntu Server 20 Image with .NET 6 Preview
 
-This is a sample template that demonstrates how to use the EC2 Image Builder CloudFormation resources to build an Ubuntu Server 20 Amazon Machine Image (AMI) with the latest .NET Preview (RC1).
+This is a sample template that demonstrates how to use the EC2 Image Builder CloudFormation resources to build an Ubuntu Server 20 Amazon Machine Image (AMI) with the latest .NET 6 Preview.
 
 This template works in standard and GovCloud (US) regions.
 
-***Internet connectivity is required in your default VPC*** to download the .NET 5 installation files. If you do not have a default VPC, or want to use a custom VPC, you will need to specify a subnet ID and one or more security group IDs in the VPC as parameters when you create a stack based on this template.
+***Internet connectivity is required in your default VPC*** to download the .NET 6 installation files. If you do not have a default VPC, or want to use a custom VPC, you will need to specify a subnet ID and one or more security group IDs in the VPC as parameters when you create a stack based on this template.
 
 ## How this Stack Works
 
@@ -28,12 +28,18 @@ Finally, the image resource is used to create an [AWS::SSM::Parameter](https://d
 
 It takes approximately 20 minutes for the stack build to complete.
 
-1. Upload the ```ubuntuserver20-with-.net5.yml``` template to CloudFormation.
+1. Upload the ```ubuntuserver20-with-.net6.yml``` template to CloudFormation.
 2. You will see a checkbox informing you that the stack creates IAM resources. Read and check the box.
 3. Wait for the stack to build.
-4. Note the AWS::ImageBuilder::Image resource ```UbuntuServer20WithNET5``` will show ```CREATE_IN_PROGRESS``` while the image is being created, and will later show ```CREATE_COMPLETE``` when complete.
+4. Note the AWS::ImageBuilder::Image resource ```UbuntuServer20WithNET6``` will show ```CREATE_IN_PROGRESS``` while the image is being created, and will later show ```CREATE_COMPLETE``` when complete.
 
 ## Troubleshooting
+
+### Instance Type is not available in the current region
+
+If you received an error like `None of the provided Instance Types are available in the current region.`, try changing the `BuildInstanceType` parameter to an Instance Type that is available in the AWS Region you're using.
+
+### AWS Systems Manager Automation
 
 While the stack is building, you will see an EC2 instance running. This is either the build or test instance. AWS Systems Manager (SSM) Automation will also run. You can observe this automation to see the steps EC2 Image Builder takes to build your image.
 
@@ -43,6 +49,6 @@ If the stack fails, check the CloudFormation events. These events include a desc
 
 To delete the resources created by the stack:
 
-1. Delete the contents of the S3 bucket created by the stack (if the bucket is not empty, the stack deletion will fail). To keep the bucket, add a ```Retain``` deletion policy to the CloudFormation bucket resource. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html for more information on ```DeletionPolicy``` attributes.
+1. Delete the contents of the S3 bucket created by the stack (if the bucket is not empty, the stack deletion will fail). To keep the bucket, add a ```Retain``` deletion policy to the CloudFormation bucket resource. See [DeletionPolicy attribute](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-deletionpolicy.html) for more information on ```DeletionPolicy``` attributes.
 2. Delete the stack in the CloudFormation console, or by using the CLI/SDK.
 3. You must delete any AMIs created by the stack. You can use the EC2 console, CLI, or SDK to delete the AMIs. Note that deleting the CloudFormation stack will NOT delete the AMIs created by the stack.

--- a/CloudFormation/Linux/ubuntu-with-net6/ubuntuserver20-with-.net6.yml
+++ b/CloudFormation/Linux/ubuntu-with-net6/ubuntuserver20-with-.net6.yml
@@ -114,17 +114,17 @@ Resources:
   # validation step which will run after the install but before the image capture. Also included, is a test step which
   # runs after the image is captured (EC2 Image Builder launches a new instance from the image and runs the test phase).
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-component.html
-  InstallNET5Component:
+  InstallNET6Component:
     Type: AWS::ImageBuilder::Component
     Properties:
-      Name: NET5
+      Name: NET6
       Version: 0.0.1
       Description: Install the latest .NET 5 preview.
       ChangeDescription: First version
       Platform: Linux
       Data: |
-        name: InstallNET5
-        description: Downloads and Installs the latest .NET 5 preview
+        name: InstallNET6
+        description: Downloads and Installs the latest .NET 6 preview
         schemaVersion: 1.0
         constants:
           - InstallScriptSource:
@@ -132,7 +132,10 @@ Resources:
               value: https://aka.ms/install-dotnet-preview
           - Version:
               type: string
-              value: '5.0'
+              value: '6.0'
+          - TestFolder:
+              type: string
+              value: '/dotnet_test'
         phases:
           - name: build
             steps:
@@ -150,7 +153,7 @@ Resources:
                 inputs:
                   - source: '{{ InstallScriptSource }}'
                     destination: '{{ build.InstallFolder.outputs.stdout }}/install.sh'
-              - name: InstallNET5
+              - name: InstallNET6
                 action: ExecuteBash
                 inputs:
                   commands:
@@ -196,28 +199,23 @@ Resources:
 
           - name: test
             steps:
-              - name: InstallFolder
-                action: ExecuteBash
-                inputs:
-                  commands:
-                    - echo "$HOME/dotnet_test"
               - name: CreateInstallFolder
                 action: CreateFolder
                 inputs:
-                  - path: '{{ test.InstallFolder.outputs.stdout }}'
+                  - path: '{{ TestFolder }}'
               - name: GenerateSample
                 action: ExecuteBash
                 inputs:
                   commands:
                     - 'set -e'
-                    - 'cd {{ test.InstallFolder.outputs.stdout}}'
-                    - 'dotnet new console --name sample'
+                    - 'cd {{ TestFolder }}'
+                    - 'DOTNET_CLI_HOME={{ TestFolder }} DOTNET_CLI_TELEMETRY_OPTOUT=1 HOME="/$(whoami)" dotnet new console --name sample'
               - name: ValidateSample
                 action: ExecuteBash
                 inputs:
                   commands:
                     - |
-                      FILE={{ test.InstallFolder.outputs.stdout }}/sample/sample.csproj
+                      FILE={{ TestFolder }}/sample/sample.csproj
                       if [ -e $FILE ]; then
                         echo "Found generated sample project. Proceeding."
                       else
@@ -227,10 +225,10 @@ Resources:
 
   # Recipe which references the latest (x.x.x) version of Ubuntu Server 20 AMI.
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html
-  UbuntuServer20NET5ImageRecipe:
+  UbuntuServer20NET6ImageRecipe:
     Type: AWS::ImageBuilder::ImageRecipe
     Properties:
-      Name: UbuntuServer20NET5
+      Name: UbuntuServer20NET6
       Version: 0.0.1
       # ${AWS::Partition} returns the partition where you are running the CloudFormation template. For standard AWS regions, the
       # partition is aws. For resources elsewhere, the partition is aws-partitionname. For example, China (Beijing and Ningxia)
@@ -240,26 +238,35 @@ Resources:
         Fn::Sub: arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/ubuntu-server-20-lts-x86/x.x.x
       Components:
         - ComponentArn:
-            Ref: InstallNET5Component
+            Ref: InstallNET6Component
+
+  # The CloudWatch LogGroup for the image build logs is provided to ensure the LogGroup is cleaned up if the stack is deleted.
+  UbuntuServer20Net6LogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/UbuntuServer20NET6
+      RetentionInDays: 3
 
   # The Image resource will show complete in CloudFormation once your image is done building. Use this resource later in your
   # stack to reference the image within other resources.
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-image.html
-  UbuntuServer20WithNET5:
+  UbuntuServer20WithNET6:
     Type: AWS::ImageBuilder::Image
     Properties:
       ImageRecipeArn:
-        Ref: UbuntuServer20NET5ImageRecipe
+        Ref: UbuntuServer20NET6ImageRecipe
       InfrastructureConfigurationArn:
         Ref: UbuntuServer20ImageInfrastructureConfiguration
 
   # Create an SSM Parameter Store entry with our resulting ImageId.
   # https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ssm-parameter.html
-  UbuntuServer20WithNET5Parameter:
+  UbuntuServer20WithNET6Parameter:
     Type: AWS::SSM::Parameter
     Properties:
       Description: Image Id for Ubuntu Server 20 With latest .NET 5 preview
-      Name: /Test/Images/UbuntuServer20WithNET5
+      Name: /Test/Images/UbuntuServer20WithNET6
       Type: String
       Value:
-        Fn::GetAtt: [UbuntuServer20WithNET5, ImageId]
+        Fn::GetAtt: [UbuntuServer20WithNET6, ImageId]


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This PR updates the existing CloudFormation samples for .NET 5 Preview to support the changes with .NET 6 Preview.

The README is updated accordingly, and includes an additional statement for troubleshooting failures due to Instance Type's not being available in-region.

For the component, the underlying source and installer URI are the same, however some changes were required to add additional environment variables when executes the test phase, and I moved one additional step to a constant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
