### PR TITLE
Fix typos which refer to Windows Server in the Ubuntu example directory

### DIFF
--- a/CloudFormation/Linux/ubuntu-2004-with-latest-ssm-agent/README.md
+++ b/CloudFormation/Linux/ubuntu-2004-with-latest-ssm-agent/README.md
@@ -18,7 +18,7 @@ Then, an [AWS::IAM::InstanceProfile](https://docs.aws.amazon.com/AWSCloudFormati
 
 Next, an [AWS::ImageBuilder::InfrastructureConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-infrastructureconfiguration.html) resource is created, and the Instance Profile is specified as one of its parameters. This parameter tells EC2 Image Builder to use the specified profile with the EC2 ]instance during the build.
 
-The [AWS::ImageBuilder::ImageRecipe](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html) ties together the Windows Server parent image and the customer userdata to upgrade the SSM Agent.
+The [AWS::ImageBuilder::ImageRecipe](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-imagerecipe.html) ties together the Ubuntu parent image and the custom userdata to upgrade the SSM Agent.
 
 The [AWS::ImageBuilder::Image](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-imagebuilder-image.html) represents the built image.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes typos which refer to Windows Server in the README for the Ubuntu example directory

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.