### PR TITLE
Update ECRRepository property

### DIFF
--- a/CloudFormation/Docker/amazon-linux-2-with-helloworld/amazon-linux-2-container-image.yml
+++ b/CloudFormation/Docker/amazon-linux-2-with-helloworld/amazon-linux-2-container-image.yml
@@ -51,7 +51,7 @@ Resources:
     Properties: 
       RepositoryName: !Ref TargetECRRepository
       ImageScanningConfiguration:
-        scanOnPush: "true"
+        ScanOnPush: "true"
 
   # By default, AWS Services do not have permission to perform actions on your instances. This grants
   # AWS Systems Manager (SSM) and EC2 Image Builder the necessary permissions to build a container image.

--- a/CloudFormation/Docker/amazon-linux-2-with-helloworld/amazon-linux-2-container-image.yml
+++ b/CloudFormation/Docker/amazon-linux-2-with-helloworld/amazon-linux-2-container-image.yml
@@ -51,7 +51,7 @@ Resources:
     Properties: 
       RepositoryName: !Ref TargetECRRepository
       ImageScanningConfiguration:
-        ScanOnPush: "true"
+        ScanOnPush: true
 
   # By default, AWS Services do not have permission to perform actions on your instances. This grants
   # AWS Systems Manager (SSM) and EC2 Image Builder the necessary permissions to build a container image.


### PR DESCRIPTION
*Issue #, if available:*
Received an status reason in Cloudformation creation for AWS::ECR::Repository saying template validation failed stating the sub-property of scanOnPush was non-permitted and deemed as an extraneous key.

*Description of changes:*
The ImageScanningConfiguration property for the AWS::ECR::Repository resource appears to be ScanOnPush and was a typo.

Reference: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ecr-repository-imagescanningconfiguration.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.