### PR TITLE
Added support for distributing AMIs to multiple regions

### DIFF
--- a/lambda/latest_image_tracker/image-builder-lambda-update-ssm.py
+++ b/lambda/latest_image_tracker/image-builder-lambda-update-ssm.py
@@ -1,12 +1,13 @@
 import json
 import boto3
-import logging 
+import logging
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-ssm_client = boto3.client('ssm')
 ssm_parameter_name = '/ec2-imagebuilder/latest'
+session = boto3.session.Session()
+
 
 def lambda_handler(event, context):
     logger.info('Printing event: {}'.format(event))
@@ -15,66 +16,56 @@ def lambda_handler(event, context):
 
 
 def process_sns_event(event):
-    for record in (event['Records']):
+    for record in event['Records']:
         event_message = record['Sns']['Message']
 
-        #convert the event message to json
+        # convert the event message to json
         message_json = json.loads(event_message)
 
-        #obtain the image state
-        image_state = (message_json['state']['status'])
-     
-        #update the SSM parameter if the image state is available
-        if (image_state == 'AVAILABLE'):
+        # obtain the image state
+        image_state = message_json['state']['status']
+
+        # update the SSM parameter if the image state is available
+        if image_state == 'AVAILABLE':
             logger.info('Image is available')
 
-            #obtain ami id
-            ami = message_json['outputResources']['amis'][0]
             recipe_name = message_json['name']
-            logger.info('AMI ID: {}'.format(ami['image']))
 
-            #update SSM parameter
-            response = ssm_client.put_parameter(
-                Name=ssm_parameter_name,
-                Description='Latest AMI ID',
-                Value=ami['image'],
-                Type='String',
-                Overwrite=True,
-                Tier='Standard'
+            for ami in message_json['outputResources']['amis']:
+                # obtain ami id
+                logger.info('AMI ID: {}'.format(ami['image']))
+
+                # update SSM parameter
+                ssm_client = session.client(
+                    service_name='ssm',
+                    region_name=ami['region'],
                 )
-            logger.info('SSM Updated: {}'.format(response))
+                response = ssm_client.put_parameter(
+                    Name=ssm_parameter_name,
+                    Description='Latest AMI ID',
+                    Value=ami['image'],
+                    Type='String',
+                    Overwrite=True,
+                    Tier='Standard',
+                )
+                logger.info('SSM Updated: {}'.format(response))
 
-            #add tags to the SSM parameter
-            ssm_client.add_tags_to_resource(
-            ResourceType='Parameter',
-            ResourceId=ssm_parameter_name,
-            Tags=[
-                {
-                    'Key': 'Source',
-                    'Value': 'EC2 Image Builder'
-                },
-                {
-                    'Key': 'AMI_REGION',
-                    'Value': ami['region']
-                },
-                {
-                    'Key': 'AMI_ID',
-                    'Value': ami['image']
-                },
-                {
-                    'Key': 'AMI_NAME',
-                    'Value': ami['name']
-                },
-                {
-                    'Key': 'RECIPE_NAME',
-                    'Value': recipe_name
-                },
-                {
-                    'Key': 'SOURCE_PIPELINE_ARN',
-                    'Value': message_json['sourcePipelineArn']
-                },
-            ],
-        )
+                # add tags to the SSM parameter
+                ssm_client.add_tags_to_resource(
+                    ResourceType='Parameter',
+                    ResourceId=ssm_parameter_name,
+                    Tags=[
+                        {'Key': 'Source', 'Value': 'EC2 Image Builder'},
+                        {'Key': 'AMI_REGION', 'Value': ami['region']},
+                        {'Key': 'AMI_ID', 'Value': ami['image']},
+                        {'Key': 'AMI_NAME', 'Value': ami['name']},
+                        {'Key': 'RECIPE_NAME', 'Value': recipe_name},
+                        {
+                            'Key': 'SOURCE_PIPELINE_ARN',
+                            'Value': message_json['sourcePipelineArn'],
+                        },
+                    ],
+                )
 
-    # end of Lambda function    
+    # end of Lambda function
     return None

--- a/lambda/latest_image_tracker/template.yml
+++ b/lambda/latest_image_tracker/template.yml
@@ -12,7 +12,7 @@ Resources:
     Type: "AWS::Serverless::Function"
     Properties:
       Handler: image-builder-lambda-update-ssm.lambda_handler
-      Runtime: python3.7
+      Runtime: python3.8
       CodeUri: .
       Description: Update SSM Parameter with the latest AMI
       MemorySize: 256
@@ -24,7 +24,6 @@ Resources:
           Properties:
             Topic: !Ref ImageBuilderSNSTopic
       Policies:
-          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
           - Version: '2012-10-17'
             Statement:
               - Effect: Allow
@@ -32,7 +31,7 @@ Resources:
                   - ssm:PutParameter
                   - ssm:AddTagsToResource
                   - ssm:GetParameters
-                Resource: '*'
+                Resource: !Sub arn:${Partition}:ssm:${Region}:${Account}:parameter/*
 
 Outputs:
   LambdaArn:
@@ -46,6 +45,3 @@ Outputs:
     Value: !Ref ImageBuilderSNSTopic
     Export:
       Name: image-builder-lambda-sns-arn
-
-
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

Now loops through AMI array instead of writing a parameter for the first AMI only. Uses the region from the AMI definition to switch the boto ssm client to the relevant region. 

Also removed duplicate Lambda managed policy, unneeded inline policy actions and overly broad resource scope.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
