### PR TITLE
Add container bootstrap and build script to setup Image Builder container build on local.

### DIFF
--- a/Containers/Scripts/README.md
+++ b/Containers/Scripts/README.md
@@ -1,0 +1,55 @@
+# Build Amazon EC2 Image Builder container images on local.
+
+This folder contains sample scripts that demonstrate how to build a docker container image locally on a Linux machine. These steps are part of the EC2 Image Builder build process.
+
+```Note: The scripts used might not be the latest, as EC2 Image Builder continously improves the build process. The intent is to provide a general overview of the EC2 Image Builder container build process.```
+
+
+## Pre-requisites
+To run the steps in this README, you will need:
+
+1. An AWS account.
+2. The following AWS Identity and Access Management (IAM) permission: imagebuilder:GetContainerRecipe (Use an IAM Role attached to an EC2 Instance, or an IAM User/Role on a local Linux machine).
+3. An EC2 Image Builder component. **Note:** *Make sure to record the ARN for later use.*
+4. An EC2 Image Builder container recipe. **Note:** *Make sure to record the ARN for later use.*
+5. A Linux system or EC2 Linux instance where you run the scripts.
+6. AWS CLI V2 installed. If you are using AWS CLI V1, you can either [uninstall](https://docs.aws.amazon.com/cli/v1/userguide/install-linux-al2017.html) or [update](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) to V2. Refer to troubleshooting section for more information.
+7. AWS CLI version 2 installed on the Linux system or EC2 Linux instance where you run the scripts. 
+   1. To verify the version you have installed, run the ```aws --version``` command. [Install AWS CLI version 2](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) if it's not already installed or if you have version 1 installed, and run the aws --version command again.
+   2. *Note:* If the version command still shows an older version after you installed version 2, you might need to run the following command to update the path for the root user: ```ln -sf /usr/local/bin/aws /usr/bin/aws```.
+
+
+## Steps
+1. Launch a Linux EC2 Instance if you are not using a Linux system. For more information, see [Launch EC2 instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EC2_GetStarted.html#ec2-launch-instance).
+2. Connect to the EC2 Instance using SSH. For more information, see [Access EC2 Instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AccessingInstancesLinux.html).
+3. Run the ```bootstrap-script-linux.sh``` script:
+    1. Change the file permissions to allow you to run the script. ```chmod +x bootstrap-script-linux.sh```
+    2. Run the script: ```./bootstrap-script-linux.sh```
+    
+    **Note**: *You might need elevated permissions to run the script. Use ```sudo su```.*
+
+4. Update the AWS credentials to allow access to Image Builder resources from the location where the script runs, as follows.
+    1. **From a local machine**, Use the ```aws configure``` command to set up your credentials. For more information, see [Configure AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html).
+    2. **From an EC2 instance**, You can use ```aws configure``` command or attach an IAM role that has Image Builder permissions to the instance. For more information, see [IAM roles for EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).
+5. In the ```container-build-script.sh``` file, replace the following:
+    1. Replace ```<Image Builder Component ARN>``` with your build component ARN.
+    2. Replace ```<Container Recipe ARN>``` with your container recipe ARN.
+    3. Replace ```<Region>``` the AWS Region where you want to build.
+6. Execute ```container-build-script.sh```
+    1. Update the file permissions to allow you to run the script. ```chmod +x container-build-script.sh```
+    2. Run the script. ```./container-build-script.sh```
+    
+    **Note**: *You might need sudo permissions to run the script. Use ```sudo su```*.
+
+## Validation and Troubleshooting
+1. Verify that the container was created: ```docker image ls```
+2. To verify that the script ran successfully, check the exit code of the container: ```docker ps -a```
+3. Verify that the expected files were modified during the container build: ```docker diff <CONTAINER_ID>```
+    **Note:**  *Use the ```docker ps -a``` command to find the ```CONTAINER_ID```*
+4. After you have verified the diff in the docker image, run the following commands to build the container:
+    1. ```docker commit <CONTAINER_ID> image_for_testing```
+    2. ```docker run -it --name troubleshooting_container image_for_testing /bin/bash```
+    
+## Cleanup
+If you are running from an EC2 instance, Follow these [steps](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#terminating-instances-console) to terminate the instance.
+**Note:** *Remember to save your data before you terminate the EC2 Instance.*

--- a/Containers/Scripts/bootstrap-script-linux.sh
+++ b/Containers/Scripts/bootstrap-script-linux.sh
@@ -1,0 +1,136 @@
+#!/bin/bash -xe
+
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Create working directory if does not exists
+if [ ! -d /tmp/imagebuilder_service ]; then
+  mkdir -p /tmp/imagebuilder_service;
+fi
+
+# Stop ECS service if running
+if systemctl --type service | grep -q "ecs"; then
+    sudo systemctl stop ecs
+fi
+
+function package_exists() {
+    $(type "$1" > /dev/null 2>&1 )
+    return $?
+}
+
+function install_package() {
+    if package_exists yum ; then
+        yum install -y -q $1
+    elif package_exists apt-get ; then
+        apt-get update -y -qq
+        apt-get install -y -qq $1
+    else
+        echo "Unable to install package '$1'"
+        exit -1
+    fi
+}
+if ! package_exists unzip ; then
+    install_package unzip
+fi
+
+# Install AWS ClI
+if ! package_exists aws ; then
+    ARCH=$(uname -m)
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-$ARCH.zip" -o "/tmp/imagebuilder_service/awscli.zip"
+    sudo unzip -o /tmp/imagebuilder_service/awscli.zip -d /tmp/imagebuilder_service
+    /tmp/imagebuilder_service/aws/install
+    ln -sf /usr/local/bin/aws /usr/bin/aws
+else
+    echo "AWS CLI already installed. Skipping install"
+fi
+
+# Install dependencies
+sudo curl -sSL "https://git.io/get-mo" -o "/tmp/imagebuilder_service/mo"
+sudo chmod +x /tmp/imagebuilder_service/mo
+
+# Start Docker
+NAME=$(uuidgen)
+if ! package_exists docker ; then
+    install_package docker
+fi
+sudo service docker start
+output=$(bash -c 'docker ps' '2>&1'); i=0;
+    while [[ $output == *'connection reset by peer'* ]];
+        do sleep 1; let 'i++';
+        if [ $i -eq 600 ]; then
+            echo 'Docker failed to start';
+            exit 1;
+        fi;
+    output=$(bash -c 'docker ps' '2>&1');
+done
+
+# Install dependencies
+cat << 'EOS' > /tmp/imagebuilder_service/container_bootstrap.sh
+#!/bin/bash -xe
+
+function package_exists() {
+    $(type "$1" > /dev/null 2>&1 )
+    return $?
+}
+
+function install_package() {
+    if package_exists yum ; then
+        yum install -y -q $1
+    elif package_exists apt-get ; then
+        apt-get update -y -qq
+        apt-get install -y -qq $1
+    else
+        echo "Unable to install package '$1'"
+        exit -1
+    fi
+}
+
+if ! package_exists which ; then
+    install_package which
+fi
+
+if ! package_exists sudo ; then
+    install_package sudo
+fi
+
+if ! package_exists curl ; then
+    install_package curl
+fi
+
+EOS
+
+cat << 'EOF' > /tmp/imagebuilder_service/container_cleanup.sh
+#!/bin/bash -xe
+
+function package_exists() {
+    $(type "$1" > /dev/null 2>&1 )
+    return $?
+}
+
+function clear_package_cache() {
+    if package_exists yum ; then
+        yum clean all
+        rm -rf /var/cache/yum
+    fi
+
+    if package_exists apt-get ; then
+        apt-get clean
+    fi
+}
+
+clear_package_cache
+
+EOF

--- a/Containers/Scripts/container-build-script.sh
+++ b/Containers/Scripts/container-build-script.sh
@@ -1,0 +1,180 @@
+#!/bin/bash -xe
+
+function pre_execute() {
+    if [ -f "/tmp/imagebuilder_service/TOE_EXIT_CODE" ] ; then
+        EXIT_CODE=$(</tmp/imagebuilder_service/TOE_EXIT_CODE)
+        cat /tmp/imagebuilder_service/TOE_LOGS
+        exit -1
+    fi
+}
+
+pre_execute
+
+cat << 'EOF' > /tmp/imagebuilder_service/docker-build.sh
+#!/bin/bash
+
+# Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this
+# software and associated documentation files (the "Software"), to deal in the Software
+# without restriction, including without limitation the rights to use, copy, modify,
+# merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+# PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+WORKING_DIR="/tmp"
+IMAGE_BUILDER_DIR="${WORKING_DIR}/imagebuilder"
+TOE_DIR="${IMAGE_BUILDER_DIR}/TaskOrchestratorAndExecutor"
+TOE_LOG_DIR="/var/lib/amazon/toe"
+BOOTSTRAP_DIR="${IMAGE_BUILDER_DIR}/bootstrap"
+
+function error_exit {
+        echo $1
+        echo "{\\"failureMessage\\":\\"$2\\"}"
+        exit 1
+}
+
+function package_exists() {
+    if [ $1 == "TOE" ] ; then
+        if [ -f "${TOE_DIR}/awstoe" ]; then return 0
+        else return 1
+        fi
+    else
+        $(type "$1" > /dev/null 2>&1 )
+        return $?
+    fi
+}
+
+function install_package() {
+    if [ $1 == "TOE" ] ; then
+        if ! package_exists curl ; then
+            install_package curl
+        fi
+        curl https://ec2imagebuilder-toe-<REGION>-prod.s3.<REGION>.amazonaws.com/bootstrap_scripts/bootstrap.sh -o ${TOE_DIR}/bootstrap.sh --silent --create-dirs
+        chmod +x ${TOE_DIR}/bootstrap.sh
+        stderr=$(${TOE_DIR}/bootstrap.sh ${TOE_DIR} 2>&1)
+        if [ $? -ne 0 ]; then
+            error_exit "$stderr" "Unable to bootstrap TOE"
+        fi
+        if [ -f "${BOOTSTRAP_DIR}/curl" ] ; then
+            remove_package curl
+            rm -f ${BOOTSTRAP_DIR}/curl
+        fi
+    elif package_exists yum ; then
+        yum install -y -q $1
+    elif package_exists apt-get ; then
+        apt-get update -y -qq
+        apt-get install -y -qq $1
+    else
+        echo "Unable to install package '$1'"
+        exit -1
+    fi
+
+    touch ${BOOTSTRAP_DIR}/$1
+}
+
+function remove_package() {
+    if [ $1 == "TOE" ] ; then
+        rm -rf ${TOE_DIR}
+    elif package_exists yum ; then
+        yum remove -y -q $1
+    elif package_exists apt-get ; then
+        apt-get remove -y -qq $1
+    else
+        echo "Unable to remove package '$1'"
+        exit -1
+    fi
+}
+
+function bootstrap() {
+    mkdir -p ${BOOTSTRAP_DIR}
+    if ! package_exists TOE ; then
+        install_package TOE
+    fi
+}
+
+function cleanup() {
+    for filename in $(ls ${BOOTSTRAP_DIR}/)
+    do
+        if [ "TOE" != $filename ] ; then
+            remove_package $filename
+        fi
+    done
+}
+
+function cleanup_toe() {
+    if [[ -d "${TOE_LOG_DIR}" ]]; then
+        rm -rf ${TOE_LOG_DIR}
+    fi
+    if [[ -d "${IMAGE_BUILDER_DIR}" ]]; then
+        rm -rf ${IMAGE_BUILDER_DIR}
+    fi
+}
+
+function pre_execute() {
+    if [ ! -f "${WORKING_DIR}/perform_cleanup" ] ; then
+        touch ${WORKING_DIR}/perform_cleanup
+    fi
+
+    if [ -f "${IMAGE_BUILDER_DIR}/TOE_EXIT_CODE" ] ; then
+        EXIT_CODE=$(<${IMAGE_BUILDER_DIR}/TOE_EXIT_CODE)
+        cat ${IMAGE_BUILDER_DIR}/TOE_LOGS
+        exit $EXIT_CODE
+    fi
+}
+
+pre_execute
+
+bootstrap
+
+cat << 'EOS' > ${IMAGE_BUILDER_DIR}/build_input_config.json
+{
+  "phases": "build,validate",
+  "documents": [
+    {
+      "path": "<Image Builder Component ARN>"
+    }
+  ]
+}
+EOS
+
+PHASE=build,validate
+
+AWSTOE_IMAGEBUILDER_ENDPOINT=https://imagebuilder.<REGION>.amazonaws.com ${TOE_DIR}/awstoe run --config ${IMAGE_BUILDER_DIR}/build_input_config.json -p ${PHASE} -l ${TOE_LOG_DIR} | tee ${IMAGE_BUILDER_DIR}/TOE_LOGS
+
+EXIT_CODE=${PIPESTATUS[0]}
+if [ $EXIT_CODE != "194" ] ; then
+    echo "$EXIT_CODE" > "${IMAGE_BUILDER_DIR}/TOE_EXIT_CODE"
+fi
+
+if [ $EXIT_CODE != "0" ] ; then
+    exit $EXIT_CODE
+fi
+
+cleanup
+cleanup_toe
+EOF
+
+aws imagebuilder get-container-recipe --container-recipe-arn <Container Recipe ARN>  --endpoint-url https://imagebuilder.<REGION>.amazonaws.com --region <REGION> --query 'containerRecipe.dockerfileTemplateData' --output text > /tmp/imagebuilder_service/dockerfile_template
+
+sed -i 's/imagebuilder:parentImage/parentImage/g; s/imagebuilder:environments/environments/g; s/imagebuilder:components/components/g' /tmp/imagebuilder_service/dockerfile_template
+
+echo "$(</tmp/imagebuilder_service/dockerfile_template)" | parentImage="amazonlinux:latest" environments="WORKDIR /tmp
+COPY container_bootstrap.sh docker-build.sh container_cleanup.sh /tmp/" components="RUN chmod +x /tmp/container_bootstrap.sh && /tmp/container_bootstrap.sh && chmod +x /tmp/docker-build.sh && /tmp/docker-build.sh && chmod +x /tmp/container_cleanup.sh && /tmp/container_cleanup.sh && rm -f /tmp/container_bootstrap.sh && rm -f /tmp/docker-build.sh && rm -f /tmp/container_cleanup.sh" /tmp/imagebuilder_service/mo > /tmp/imagebuilder_service/Dockerfile
+
+NAME=$(uuidgen)
+echo ${NAME} > /tmp/imagebuilder_service/image-name
+docker build -t ${NAME} -f /tmp/imagebuilder_service/Dockerfile /tmp/imagebuilder_service | tee /tmp/imagebuilder_service/TOE_LOGS
+
+EXIT_CODE=${PIPESTATUS[0]}
+if [ $EXIT_CODE != "0" ] ; then
+    echo "$EXIT_CODE" > /tmp/imagebuilder_service/TOE_EXIT_CODE
+    exit -1
+fi

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ The ```CDK``` folder contains sample EC2 Image Builder Cloud Development Kit. Th
 
 ### Components
 
-The ```Components``` contains sample Image Builder components. The samples demonstrate how certain features of the component management application work, or how to execute certain workflows, such as invoking ```ansible-playbook``` or ```chef-client``` within a component.
+The ```Components``` folder contains sample Image Builder components. The samples demonstrate how certain features of the component management application work, or how to execute certain workflows, such as invoking ```ansible-playbook``` or ```chef-client``` within a component.
+
+### Containers
+
+The ```Containers``` folder contains scripts used by EC2 Image Builder during docker image build. The samples demonstrate how to build container images following the steps followed by EC2 Image Builder.
+
 
 ## Additional Learning Resources
 


### PR DESCRIPTION
The pull request contains bootstrap and build script used by Image Builder to create container images.

These scripts are used as a reference for the blog post to be published by AWS Blog Post team.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
