### PR TITLE
Add a golden-AMI loop sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ From there:
 |---|---|
 | [quick-start](quick-start/) | The smallest complete pipeline - CloudFormation and CDK (`@aws-cdk/aws-imagebuilder-alpha` L2) variants side by side, x-wildcard auto-versioning throughout, and an arm64 toggle |
 | [distribution/cross-account-amis](distribution/cross-account-amis/) | Cross-account AMI distribution: a CMK with a least-privilege key policy, the target-account role, and per-account SSM parameters holding each account's AMI ID |
+| [golden-ami-pipeline](golden-ami-pipeline/) | The golden-AMI loop end to end: monthly patching from an SSM-parameter base, launch template promotion, an instance refresh that automatically moves the running Auto Scaling group onto each new AMI, and build events turned into readable pass/fail notifications |
 
 ### CloudFormation - Linux AMIs
 

--- a/golden-ami-pipeline/README.md
+++ b/golden-ami-pipeline/README.md
@@ -1,0 +1,76 @@
+# The golden-AMI loop, end to end
+
+Most Image Builder samples stop when the AMI exists. This one closes the loop: a scheduled pipeline patches your base image monthly, distribution publishes the result to an SSM parameter and promotes it to the default launch template version, and an EventBridge-triggered Lambda rolls the Auto Scaling group onto the new AMI with an instance refresh. A second Lambda turns the service's image state-change events into readable one-line summaries.
+
+Everything lives in one CloudFormation template: [golden-ami-pipeline.yml](golden-ami-pipeline.yml).
+
+## The loop
+
+1. **Base in**: the recipe's parent image is `ssm:/golden-ami/base-ami` - an SSM parameter this stack owns. Update the parameter, and the next run builds from the new base. (Stack updates re-resolve `SeedAmiId` and can reset this parameter to the seed value - re-apply a custom base after updating the stack.) Public parameters work in this position too, with no extra IAM - for example Canonical's Ubuntu 26.04 parameter (`/aws/service/canonical/ubuntu/server/26.04/stable/current/amd64/hvm/ebs-gp3/ami-id`, the seed default).
+2. **Patch monthly**: the pipeline runs `update-linux` on a monthly cron. The start condition is `EXPRESSION_MATCH_ONLY` on purpose: the alternative (`EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE`) skips runs when no *recipe dependency* changed - but OS packages update continuously without any recipe dependency changing, so a patch pipeline must build every cycle unconditionally. Note: in-place patching fits OSes with rolling package repositories, like the Ubuntu base here. Amazon Linux 2023 delivers OS updates as new immutable releases instead - for an AL2023 fleet, patch by moving the base parameter to each new AL2023 AMI.
+3. **Publish**: distribution writes the AMI ID to `/golden-ami/latest-ami` and adds a launch template version with the new AMI, promoting it to the default.
+4. **Roll the fleet**: when the image reaches `AVAILABLE`, an EventBridge rule fires the refresh Lambda, which starts an Auto Scaling instance refresh onto the default template version (if a refresh is already rolling, the Lambda skips - the next build catches up). New instances launch from the group's template version; the refresh replaces the running ones.
+5. **Notify**: the same state-change events feed a formatter Lambda (a second target on the `AVAILABLE` rule, plus a `FAILED` rule), which fetches the build's details and publishes a one-line pass/fail summary with the AMI IDs to an encrypted topic (set the `NotificationEmail` parameter, or subscribe anything else).
+
+## Design notes
+
+- **The execution role holds exactly the deltas this setup needs**: `ssm:GetParameter` on the base parameter, `ssm:PutParameter` (plus `AddTagsToResource`) on the output one (both live under `/golden-ami/`, outside the `/imagebuilder/` paths the managed execution policy covers), and CloudWatch Logs writes for the custom log group paths.
+- **Auto-disable**: the schedule carries an `AutoDisablePolicy` with `FailureCount: 3` - once consecutive failed scheduled runs pass that count, the service disables the pipeline instead of letting it fail forever unattended (the default count is 5; only scheduled runs count, and any success resets the counter). The service emits an `EC2 Image Builder Image Pipeline Automatically Disabled` event when it trips - fix the failure, then set the pipeline back to `ENABLED`.
+- **The EventBridge patterns filter on this pipeline's image ARN prefix.** A pattern matching every image in the account would fire for other pipelines' images too - and for rules that *start* pipelines, that's how endless build loops happen. Scope patterns to the image name prefix.
+- **CloudFormation can't set `$Default` as an Auto Scaling group's launch template version** (the API can). The group deploys pinned to the initial version; the refresh Lambda passes a `DesiredConfiguration` targeting `$Default`, which rolls the instances *and* updates the group to track `$Default` from then on. Rollback (auto or manual) isn't available while the group tracks `$Default` - a failed refresh needs a cancel and a fresh run. Note that a later stack update re-pins the group to a numbered version (the template resolves `DefaultVersionNumber` again) until the next refresh moves it back.
+
+## Cost
+
+- The demo fleet runs `FleetSize` t3.micro instances (default 1) continuously - that's the largest ongoing cost. Set `FleetSize=0` to keep the loop without a running fleet.
+- Each monthly build bills a t3.medium for the build duration, typically 15 to 30 minutes, plus AMI snapshot storage that accumulates per build - lifecycle policies can clean old builds up automatically.
+- The KMS key bills at the standard monthly key rate until deleted.
+
+## Prerequisites
+
+- A default VPC in the deployment region. Without one, set `SubnetId`/`SecurityGroupIds` on the infrastructure configuration AND give the fleet a `VPCZoneIdentifier` - the Auto Scaling group launches into the default VPC's subnets too.
+- AWS CLI with permissions to deploy CloudFormation stacks with IAM resources.
+
+## Deploy
+
+```shell
+aws cloudformation deploy \
+  --template-file golden-ami-pipeline.yml \
+  --stack-name golden-ami-pipeline \
+  --parameter-overrides NotificationEmail=you@example.com \
+  --capabilities CAPABILITY_IAM
+```
+
+Deploying creates the pipeline and the fleet but doesn't build anything - the schedule fires monthly, or start a run now:
+
+```shell
+aws imagebuilder start-image-pipeline-execution \
+  --image-pipeline-arn <ImagePipelineArn from the stack outputs>
+```
+
+## Testing
+
+A build typically takes 15 to 30 minutes. When it completes, the loop's effects are all observable:
+
+1. `/golden-ami/latest-ami` holds the new AMI ID: `aws ssm get-parameter --name /golden-ami/latest-ami --query Parameter.Value --output text`
+2. The launch template gained a version and the default moved: `aws ec2 describe-launch-templates --launch-template-ids <LaunchTemplateId output> --query 'LaunchTemplates[0].DefaultVersionNumber'`
+3. An instance refresh is rolling (or done): `aws autoscaling describe-instance-refreshes --auto-scaling-group-name golden-ami-fleet`
+4. Once the refresh finishes, the fleet instance's `ImageId` is the new AMI.
+5. The topic delivered a readable "Image build golden-ami-loop ...: AVAILABLE" message (email if subscribed; the formatter Lambda's log group always has it).
+
+To test the base-swap path, point the base parameter somewhere else and run the pipeline again:
+
+```shell
+aws ssm put-parameter --name /golden-ami/base-ami --overwrite \
+  --value "$(aws ssm get-parameter --name /aws/service/canonical/ubuntu/server/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id --query Parameter.Value --output text)"
+```
+
+## Cleanup
+
+Deleting the stack removes the pipeline, fleet, topic, and Lambdas - but not what builds produced. In order:
+
+1. Delete the Image Builder image build versions (`aws imagebuilder delete-image --image-build-version-arn <arn>` per build).
+2. Deregister the `golden-ami-*` AMIs and delete their snapshots.
+3. Delete `/golden-ami/latest-ami` (service-written, so it outlives the stack). The base parameter is a stack resource and goes with the stack.
+4. If an instance refresh is still rolling, cancel it first (`aws autoscaling cancel-instance-refresh --auto-scaling-group-name golden-ami-fleet`) - deleting the group mid-refresh can hang stack deletion.
+5. Delete the stack: `aws cloudformation delete-stack --stack-name golden-ami-pipeline`. The fleet drains as part of stack deletion; the KMS key enters its 7-day deletion window.
+6. If a build ran recently, the custom log groups can reappear after deletion while late log deliveries land - delete them again before redeploying the same stack name, or the deploy fails on the name conflict.

--- a/golden-ami-pipeline/golden-ami-pipeline.yml
+++ b/golden-ami-pipeline/golden-ami-pipeline.yml
@@ -1,0 +1,615 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >
+  The golden-AMI loop, end to end: a scheduled EC2 Image Builder pipeline
+  patches a base image monthly, distribution publishes the new AMI to an SSM
+  parameter and promotes it to the default launch template version, and an
+  EventBridge-triggered Lambda rolls the Auto Scaling group onto it with an
+  instance refresh. A second Lambda turns image state-change events into
+  readable summaries.
+
+Parameters:
+  SeedAmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Default: /aws/service/canonical/ubuntu/server/26.04/stable/current/amd64/hvm/ebs-gp3/ami-id
+    Description: >-
+      Initial base AMI, resolved from a public SSM parameter; also the
+      launch template's first version. After deployment, the pipeline reads
+      the base from this stack's own
+      /golden-ami/base-ami parameter - update that parameter to change the
+      base without touching the stack.
+
+  NotificationEmail:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional email address for readable build notifications. Leave empty
+      to skip the subscription - the formatted summaries still land in the
+      formatter Lambda's log group.
+
+  FleetSize:
+    Type: Number
+    Default: 1
+    MinValue: 0
+    MaxValue: 4
+    Description: >-
+      Desired capacity of the demo Auto Scaling group that the instance
+      refresh rolls. Set 0 to skip running fleet instances (the refresh
+      then has nothing to do, but also no cost).
+
+Conditions:
+  HasEmail: !Not [!Equals [!Ref NotificationEmail, '']]
+
+Resources:
+  # ---------------------------------------------------------------------
+  # The golden base parameter. The recipe reads it at build time through
+  # the ssm: parent-image reference - update the value and the next
+  # scheduled run builds from the new base.
+  # ---------------------------------------------------------------------
+  BaseAmiParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /golden-ami/base-ami
+      Type: String
+      DataType: aws:ec2:image
+      Value: !Ref SeedAmiId
+      Description: The base AMI the golden pipeline builds from.
+
+  # The pipeline's execution role. The managed policy covers the standard
+  # workflow actions; the inline statements cover exactly what this stack
+  # does outside the service defaults.
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - imagebuilder.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2ImageBuilderExecutionPolicy'
+      Policies:
+        - PolicyName: GoldenAmiParameters
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # The managed execution policy only reads parameters under
+              # /imagebuilder/ and the public /aws/service/ paths - the ssm:
+              # parent reference to /golden-ami/base-ami fails without this.
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/golden-ami/base-ami'
+              # Same story on the way out: distribution writes the output
+              # parameter outside /imagebuilder/.
+              - Effect: Allow
+                Action:
+                  - ssm:PutParameter
+                  - ssm:AddTagsToResource
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/golden-ami/latest-ami'
+        - PolicyName: GoldenAmiLogGroups
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # Log group names outside /aws/imagebuilder/ require the
+              # execution role to hold the CloudWatch Logs write permissions.
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/golden-ami/*'
+
+  # ---------------------------------------------------------------------
+  # Build resources: instance profile, recipe, infrastructure.
+  # ---------------------------------------------------------------------
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+      Path: /executionServiceEC2Role/
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /executionServiceEC2Role/
+      Roles:
+        - !Ref InstanceRole
+
+  ImageRecipe:
+    Type: AWS::ImageBuilder::ImageRecipe
+    # Recipe creation validates that the ssm: parent parameter exists, so
+    # the parameter must be created first.
+    DependsOn: BaseAmiParameter
+    Properties:
+      Name: golden-ami-loop
+      Version: 1.0.x
+      # The ssm: prefix resolves the parameter at build time. Public
+      # parameters work here too with no extra IAM - for example the
+      # Canonical Ubuntu parameters (see the README).
+      ParentImage: ssm:/golden-ami/base-ami
+      # Monthly patching is the whole job: pull current updates on top of
+      # whatever the base parameter points at.
+      Components:
+        - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/update-linux/x.x.x'
+
+  InfrastructureConfiguration:
+    Type: AWS::ImageBuilder::InfrastructureConfiguration
+    Properties:
+      Name: golden-ami-loop
+      InstanceProfileName: !Ref InstanceProfile
+      InstanceTypes:
+        - t3.medium
+      InstanceMetadataOptions:
+        HttpTokens: required
+      # Build instances launch in the account's default VPC. Without a
+      # default VPC, set SubnetId and SecurityGroupIds here.
+
+  # Custom log group paths - the stack owns naming and retention. Anything
+  # outside /aws/imagebuilder/ needs the execution role's logs permissions.
+  BuildLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /golden-ami/image
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt NotificationKey.Arn
+
+  PipelineLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /golden-ami/pipeline
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt NotificationKey.Arn
+
+  # ---------------------------------------------------------------------
+  # Distribution: publish the AMI ID and promote the launch template.
+  # ---------------------------------------------------------------------
+  DistributionConfiguration:
+    Type: AWS::ImageBuilder::DistributionConfiguration
+    Properties:
+      Name: golden-ami-loop
+      Distributions:
+        - Region: !Ref AWS::Region
+          AmiDistributionConfiguration:
+            Name: 'golden-ami-{{ imagebuilder:buildDate }}'
+          # The handoff for everything that isn't the fleet below: launch
+          # templates elsewhere can use resolve:ssm:/golden-ami/latest-ami.
+          SsmParameterConfigurations:
+            - ParameterName: /golden-ami/latest-ami
+              DataType: aws:ec2:image
+          # Image Builder adds a launch template version with the new AMI
+          # and makes it the default, so anything tracking $Default - the
+          # Auto Scaling group below - picks it up.
+          LaunchTemplateConfigurations:
+            - LaunchTemplateId: !Ref FleetLaunchTemplate
+              SetDefaultVersion: true
+
+  # ---------------------------------------------------------------------
+  # The scheduled pipeline. EXPRESSION_MATCH_ONLY builds every month
+  # unconditionally: OS packages update continuously without any recipe
+  # dependency changing, so a patch pipeline must not skip "no change"
+  # months. The auto-disable policy stops a pipeline whose scheduled runs
+  # keep failing instead of letting it fail forever unattended.
+  # ---------------------------------------------------------------------
+  ImagePipeline:
+    Type: AWS::ImageBuilder::ImagePipeline
+    Properties:
+      Name: golden-ami-loop
+      Description: Monthly-patched golden AMI feeding the fleet.
+      ImageRecipeArn: !Ref ImageRecipe
+      InfrastructureConfigurationArn: !Ref InfrastructureConfiguration
+      DistributionConfigurationArn: !Ref DistributionConfiguration
+      ExecutionRole: !GetAtt ExecutionRole.Arn
+      Schedule:
+        # 06:00 UTC on the 1st of every month.
+        ScheduleExpression: 'cron(0 6 1 * ? *)'
+        PipelineExecutionStartCondition: EXPRESSION_MATCH_ONLY
+        AutoDisablePolicy:
+          FailureCount: 3
+      LoggingConfiguration:
+        ImageLogGroupName: !Ref BuildLogGroup
+        PipelineLogGroupName: !Ref PipelineLogGroup
+
+  # ---------------------------------------------------------------------
+  # The fleet: a launch template tracking the golden AMI and a small Auto
+  # Scaling group. New instances always get the default template version;
+  # the instance refresh below replaces the running ones.
+  # ---------------------------------------------------------------------
+  FleetLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: golden-ami-fleet
+      LaunchTemplateData:
+        ImageId: !Ref SeedAmiId
+        InstanceType: t3.micro
+        MetadataOptions:
+          HttpTokens: required
+
+  FleetAutoScalingGroup:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      AutoScalingGroupName: golden-ami-fleet
+      LaunchTemplate:
+        LaunchTemplateId: !Ref FleetLaunchTemplate
+        # CloudFormation can't set $Default here (the API can). The refresh
+        # Lambda moves the group onto $Default with its first
+        # DesiredConfiguration, and it sticks from then on.
+        Version: !GetAtt FleetLaunchTemplate.DefaultVersionNumber
+      MinSize: '0'
+      MaxSize: '4'
+      DesiredCapacity: !Ref FleetSize
+      # Two AZs from the default VPC. Newer AZs sometimes lack default
+      # subnets in older accounts, so the sample sticks to the first two.
+      AvailabilityZones:
+        - !Select [0, !GetAZs '']
+        - !Select [1, !GetAZs '']
+      # Give replacement instances time to boot before the refresh counts
+      # them healthy.
+      DefaultInstanceWarmup: 60
+    # Deleting the ASG mid-refresh can hang stack deletion - let a running
+    # refresh finish before deleting the stack.
+
+  # ---------------------------------------------------------------------
+  # The loop closer: when this pipeline's image reaches AVAILABLE, roll
+  # the fleet. Keep the resources filter scoped to this pipeline's images -
+  # a pattern matching every AVAILABLE image in the account would also fire
+  # for other pipelines' images (and, for rules that start pipelines, can
+  # create endless build loops).
+  # ---------------------------------------------------------------------
+  RefreshFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+        - PolicyName: StartInstanceRefresh
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - autoscaling:StartInstanceRefresh
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:autoscaling:${AWS::Region}:${AWS::AccountId}:autoScalingGroup:*:autoScalingGroupName/${FleetAutoScalingGroup}'
+              # A DesiredConfiguration launch template makes Auto Scaling
+              # re-verify launch authorization across launch and network
+              # resources - Resource '*' plus the template condition is the
+              # narrowest grant that passes that check.
+              - Effect: Allow
+                Action:
+                  - ec2:RunInstances
+                Resource: '*'
+                Condition:
+                  ArnEquals:
+                    ec2:LaunchTemplate: !Sub 'arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:launch-template/${FleetLaunchTemplate}'
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeLaunchTemplateVersions
+                Resource: '*'
+
+  # Stack-owned log group: encrypted, retention-capped, and deleted with
+  # the stack (Lambda would otherwise create an unmanaged one on first run).
+  RefreshFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /golden-ami/refresh-lambda
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt NotificationKey.Arn
+
+  RefreshFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Rolls the fleet onto the new default launch template version.
+      Runtime: python3.13
+      Handler: index.handler
+      Timeout: 30
+      Role: !GetAtt RefreshFunctionRole.Arn
+      LoggingConfig:
+        LogGroup: !Ref RefreshFunctionLogGroup
+      Environment:
+        Variables:
+          ASG_NAME: !Ref FleetAutoScalingGroup
+          LAUNCH_TEMPLATE_ID: !Ref FleetLaunchTemplate
+      Code:
+        ZipFile: |
+          import boto3
+          import os
+
+          autoscaling = boto3.client("autoscaling")
+
+          def handler(event, context):
+              image_arn = event["resources"][0]
+              try:
+                  response = autoscaling.start_instance_refresh(
+                      AutoScalingGroupName=os.environ["ASG_NAME"],
+                      # Rolls the fleet onto the current default template
+                      # version - the one distribution just promoted - and
+                      # updates the group to track $Default from here on.
+                      DesiredConfiguration={
+                          "LaunchTemplate": {
+                              "LaunchTemplateId": os.environ["LAUNCH_TEMPLATE_ID"],
+                              "Version": "$Default",
+                          }
+                      },
+                      # Rolling defaults apply: MinHealthyPercentage 90,
+                      # warmup from the group's DefaultInstanceWarmup.
+                      # AutoRollback can't be used with $Default tracking.
+                      Preferences={"SkipMatching": True},
+                  )
+                  print(f"Started refresh {response['InstanceRefreshId']} for {image_arn}")
+              except autoscaling.exceptions.InstanceRefreshInProgressFault:
+                  # A previous build's refresh is still rolling; the fleet
+                  # converges on the newest default version when it finishes.
+                  print("Refresh already in progress - skipping")
+
+  RefreshFunctionPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref RefreshFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt ImageAvailableRule.Arn
+
+  ImageAvailableRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Fires when the golden pipeline publishes a new image.
+      EventPattern:
+        source:
+          - aws.imagebuilder
+        detail-type:
+          - EC2 Image Builder Image State Change
+        detail:
+          state:
+            status:
+              - AVAILABLE
+        # Only this pipeline's images - the recipe name is the first path
+        # segment of every image build version ARN it produces.
+        resources:
+          - prefix: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/golden-ami-loop/'
+      Targets:
+        - Id: refresh-fleet
+          Arn: !GetAtt RefreshFunction.Arn
+        - Id: format-notification
+          Arn: !GetAtt FormatterFunction.Arn
+
+  # ---------------------------------------------------------------------
+  # Notifications: the same state-change events that drive the refresh
+  # feed a formatter Lambda, which publishes a one-line pass/fail summary
+  # with the AMI IDs to a topic humans can subscribe to.
+  # ---------------------------------------------------------------------
+  NotificationKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Encrypts the golden pipeline's notification topic and log groups
+      EnableKeyRotation: true
+      PendingWindowInDays: 7
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          # Keeps the key manageable and lets same-account IAM policies -
+          # like the formatter Lambda role's grant - take effect.
+          - Sid: EnableIAMUserPermissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+          # CloudWatch Logs uses the key on the log groups' behalf; the
+          # encryption context pins the grant to the /golden-ami/* groups.
+          - Sid: AllowCloudWatchLogs
+            Effect: Allow
+            Principal:
+              Service: !Sub 'logs.${AWS::Region}.amazonaws.com'
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
+            Resource: '*'
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:logs:arn: !Sub 'arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/golden-ami/*'
+
+  NotificationKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: alias/golden-ami
+      TargetKeyId: !Ref NotificationKey
+
+  ReadableNotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: golden-ami-build-summaries
+      KmsMasterKeyId: !GetAtt NotificationKey.Arn
+
+  EmailSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: HasEmail
+    Properties:
+      TopicArn: !Ref ReadableNotificationTopic
+      Protocol: email
+      Endpoint: !Ref NotificationEmail
+
+  FormatterFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+        - PolicyName: PublishSummaries
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # The event only carries the image ARN and state - AMI IDs and
+              # failure reasons come from the image itself.
+              - Effect: Allow
+                Action:
+                  - imagebuilder:GetImage
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/golden-ami-loop/*'
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource:
+                  - !Ref ReadableNotificationTopic
+              # Publishing to the encrypted topic means using its key.
+              - Effect: Allow
+                Action:
+                  - kms:GenerateDataKey*
+                  - kms:Decrypt
+                Resource:
+                  - !GetAtt NotificationKey.Arn
+
+  FormatterFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /golden-ami/formatter-lambda
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt NotificationKey.Arn
+
+  FormatterFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Turns image state-change events into readable build summaries.
+      Runtime: python3.13
+      Handler: index.handler
+      Timeout: 30
+      Role: !GetAtt FormatterFunctionRole.Arn
+      LoggingConfig:
+        LogGroup: !Ref FormatterFunctionLogGroup
+      Environment:
+        Variables:
+          SUMMARY_TOPIC_ARN: !Ref ReadableNotificationTopic
+      Code:
+        ZipFile: |
+          import boto3
+          import os
+
+          imagebuilder = boto3.client("imagebuilder")
+          sns = boto3.client("sns")
+
+          def handler(event, context):
+              image_arn = event["resources"][0]
+              status = event["detail"]["state"]["status"]
+              image = imagebuilder.get_image(imageBuildVersionArn=image_arn)["image"]
+              amis = [
+                  f"{a.get('region')}: {a.get('image')}"
+                  for a in (image.get("outputResources") or {}).get("amis", [])
+              ]
+              lines = [f"Image build {image.get('name')} {image.get('version')}: {status}"]
+              if amis:
+                  lines.append("AMIs: " + ", ".join(amis))
+              if status == "FAILED":
+                  lines.append(f"Reason: {image.get('state', {}).get('reason', 'not provided')}")
+              summary = "\n".join(lines)
+              print(summary)
+              sns.publish(
+                  TopicArn=os.environ["SUMMARY_TOPIC_ARN"],
+                  Subject=f"Golden AMI build: {status}",
+                  Message=summary,
+              )
+
+  FormatterAvailablePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref FormatterFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt ImageAvailableRule.Arn
+
+  FormatterFailedPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref FormatterFunction
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt ImageFailedRule.Arn
+
+  # Failed builds get a summary too - same formatter, separate rule so the
+  # fleet refresh only ever sees AVAILABLE images.
+  ImageFailedRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: Summarizes failed golden pipeline builds.
+      EventPattern:
+        source:
+          - aws.imagebuilder
+        detail-type:
+          - EC2 Image Builder Image State Change
+        detail:
+          state:
+            status:
+              - FAILED
+        resources:
+          - prefix: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:${AWS::AccountId}:image/golden-ami-loop/'
+      Targets:
+        - Id: format-notification
+          Arn: !GetAtt FormatterFunction.Arn
+
+Outputs:
+  ImagePipelineArn:
+    Description: >-
+      ARN of the image pipeline. Start an out-of-cycle build with 'aws
+      imagebuilder start-image-pipeline-execution --image-pipeline-arn
+      <this value>'.
+    Value: !Ref ImagePipeline
+  BaseAmiParameterName:
+    Description: Update this parameter to change the base image for future builds.
+    Value: !Ref BaseAmiParameter
+  LatestAmiParameterName:
+    Description: Receives each build's AMI ID.
+    Value: /golden-ami/latest-ami
+  FleetAutoScalingGroupName:
+    Description: The demo fleet that instance refresh rolls onto new AMIs.
+    Value: !Ref FleetAutoScalingGroup
+  LaunchTemplateId:
+    Description: The launch template whose default version tracks the golden AMI.
+    Value: !Ref FleetLaunchTemplate


### PR DESCRIPTION
# Description

Adds a "Golden AMI" sample that shows full end-to-end image build, starting from SSM Parameter, to patching the AMI with updates, and updating that same SSM Parameter as output, with automation wired up using EventBridge to deploy to ASG, and send notification at the end.

## Checklist

- [X] I deployed this sample in my own account and it created AND deleted cleanly (no leftover AMIs, snapshots, or non-empty buckets beyond what the README documents)
- [X] The README covers prerequisites, deployment, and cleanup for what I changed
- [X] No account IDs, ARNs from real accounts, or credentials anywhere in the change - including test data
- [X] If this adds a sample, it's listed in the root README index

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
