### PR TITLE
Add an image lifecycle management sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ From there:
 | [distribution/cross-account-amis](distribution/cross-account-amis/) | Cross-account AMI distribution: a CMK with a least-privilege key policy, the target-account role, and per-account SSM parameters holding each account's AMI ID |
 | [golden-ami-pipeline](golden-ami-pipeline/) | The golden-AMI loop end to end: monthly patching from an SSM-parameter base, launch template promotion, an instance refresh that automatically moves the running Auto Scaling group onto each new AMI, and build events turned into readable pass/fail notifications |
 | [networking/private-vpc-builds](networking/private-vpc-builds/) | Builds in an isolated VPC with no internet - the endpoints a build needs, the S3 bucket allowlist, and a common-errors table mapping each failure to its missing endpoint (CloudFormation and CDK) |
+| [lifecycle](lifecycle/) | Automatic cleanup of old images, AMIs, and snapshots: the retention model explained, a working count-based policy, and ready-to-use policy documents for progressive age-based and guarded deletion |
 
 ### CloudFormation - Linux AMIs
 

--- a/lifecycle/README.md
+++ b/lifecycle/README.md
@@ -1,0 +1,101 @@
+# Image lifecycle management
+
+Every pipeline run leaves behind an Image Builder image resource, an AMI, and snapshots - and they bill until something deletes them. Lifecycle policies automate that cleanup, but the retention model isn't obvious from the policy shape alone. This sample is a working policy attached to a minimal pipeline ([lifecycle-policy.yml](lifecycle-policy.yml)), plus three ready-to-use policy documents for the CLI ([policies/](policies/)).
+
+## The retention model
+
+Getting these wrong is how policies delete too much or nothing at all:
+
+1. **Policies act on Image Builder image resources, and only touch AMIs/snapshots if you say so.** The `Action.IncludeResources` block is the blast-radius control: without `Amis: true` and `Snapshots: true`, a DELETE removes only the Image Builder record and the actual AMI keeps billing.
+2. **Counting is per recipe version.** A COUNT filter of 3 keeps the newest 3 image build versions for *each* recipe version independently - 1.0.0 and 1.0.1 each keep their own 3, and a wildcard (`x.x.x`) covers every version the same way. Failed and canceled builds never count toward retention and always qualify for deletion (exclusion tags don't protect them).
+3. **For COUNT, `Value` is how many to keep** (not how many to delete). For AGE rules, `RetainAtLeast` is the floor under a DELETE - the newest N survive even past the age bar, counted per recipe version like COUNT.
+4. **One policy holds up to 3 rules, evaluated deprecate -> disable -> delete, one action per image per run.** That ordering is what makes a progressive strategy (deprecate at 90 days, disable at 120, delete at 180) work as a single policy.
+5. **Policies run once per day** at a time the service chooses. For on-demand cleanup, use `start-resource-state-update` (below) - it takes the same execution role.
+
+Selection is by recipe (name + semantic version, where `x` wildcards resolve at execution time - recipe versions created after the policy are covered automatically) or by tags **on the Image Builder image resource**. The pipeline's `ImageTags` put them there: each scheduled run stamps its image with the group tag that tag-scoped policies match on. Manually started builds don't apply `ImageTags` - tag those images with `aws imagebuilder tag-resource`.
+
+## What the actions do
+
+- **DEPRECATE** - the image stops appearing in general searches but still launches by AMI ID; with `IncludeResources`, the AMIs get a `DeprecatedBy: EC2 Image Builder` tag. A soft migrate-away signal.
+- **DISABLE** - pipelines can no longer run for the image; with `IncludeResources`, the AMIs become private, can no longer launch instances (Auto Scaling groups using them included), and accounts they were shared with lose access.
+- **DELETE** - removes the image resource, and with `IncludeResources`, deregisters the AMIs and deletes the snapshots.
+
+## The policy documents
+
+Each file in [policies/](policies/) is a complete `--cli-input-json` input - set your `executionRole` ARN, adjust names, then:
+
+```shell
+aws imagebuilder create-lifecycle-policy --cli-input-json file://policies/keep-last-n.json
+```
+
+The same fields map 1:1 into `AWS::ImageBuilder::LifecyclePolicy` properties (camelCase to PascalCase) - the template's deployed policy shows the CloudFormation shape.
+
+Note that this creates an *enabled* policy - the first daily run can act within 24 hours, so check the selection before pointing one at a busy recipe.
+
+- **[keep-last-n.json](policies/keep-last-n.json)** - keep the newest 5 images per recipe version, delete the rest with their AMIs and snapshots. Wildcard `semanticVersion: x.x.x` covers every version of the recipe, present and future.
+- **[progressive-age.json](policies/progressive-age.json)** - the three-stage strategy: deprecate at 90 days, disable at 120, delete at 180 with `retainAtLeast: 2` as the floor. Tag-scoped, so it manages every image resource tagged `LifecycleGroup: lifecycle-sample` - which the pipeline's `ImageTags` apply on each scheduled run.
+- **[guarded-delete.json](policies/guarded-delete.json)** - deletion with every guardrail shown: skip AMIs that are public, shared with specific accounts, launched in the last 30 days (EC2's last-launched data lags up to 24 hours), distributed to regions you list (the placeholder protects `us-east-1` - adjust it), or tagged `Environment: production`. These AMI-level guards protect the AMI only - the image resource still deletes around it, leaving the AMI unmanaged. To keep the pair intact, use the image-resource pin tag (`LifecyclePin: retain`). Retention counting runs before tag exclusion, so a pinned image inside the retention window still occupies a keep slot - the pin protects images beyond the window.
+
+## Cost
+
+The policy itself is free. The pipeline builds weekly until you delete the stack (plus any manual runs); each build bills a t3.medium for the build duration, typically 15 to 25 minutes (the sample component is trivial), plus AMI snapshot storage per build - which is the point: the policy caps that accumulation at 3 builds.
+
+## Prerequisites
+
+- A default VPC in the deployment region (or add `SubnetId`/`SecurityGroupIds` to the infrastructure configuration).
+- AWS CLI with permissions to deploy CloudFormation stacks with IAM resources.
+
+## Deploy
+
+```shell
+aws cloudformation deploy \
+  --template-file lifecycle-policy.yml \
+  --stack-name lifecycle-sample \
+  --capabilities CAPABILITY_IAM
+```
+
+This creates the execution role (trusting `imagebuilder.amazonaws.com`, carrying the `EC2ImageBuilderLifecycleExecutionPolicy` managed policy), a minimal weekly pipeline, and an enabled count-based policy scoped to the pipeline's recipe. The managed policy conditions its EC2 actions on the `CreatedBy: EC2 Image Builder` resource tag the service stamps on everything it distributes - the role can't touch AMIs the service didn't build.
+
+## Testing
+
+1. Run the pipeline two or three times (`aws imagebuilder start-image-pipeline-execution --image-pipeline-arn <output>`) - each build typically takes 15 to 25 minutes and must finish before the next starts.
+2. Manual runs skip the pipeline's `ImageTags`, so stamp the group tag yourself: `aws imagebuilder tag-resource --resource-arn <image build version arn> --tags LifecycleGroup=lifecycle-sample` (scheduled runs apply it automatically - confirm either with `list-tags-for-resource`).
+3. The policy holds until you exceed 3 images. Rather than building 4 times, test the mechanism with a one-off state change:
+
+```shell
+aws imagebuilder start-resource-state-update \
+  --resource-arn <image build version arn> \
+  --state status=DEPRECATED \
+  --execution-role <LifecycleExecutionRoleArn from the stack outputs> \
+  --include-resources amis=true
+```
+
+The API requires `--include-resources` whenever `--execution-role` is set. Within a minute the image's status turns `DEPRECATED` and its AMI gains the `DeprecatedBy: EC2 Image Builder` tag. Track any lifecycle run with `aws imagebuilder list-lifecycle-executions --resource-arn <arn>` (the policy ARN for scheduled runs, the image build version ARN for manual ones) and `list-lifecycle-execution-resources` (per-resource SUCCESS/FAILED/SKIPPED with reasons). Those two APIs are the monitoring path for lifecycle runs.
+
+For one-off deletion (image + AMIs + snapshots in one call):
+
+```shell
+aws imagebuilder start-resource-state-update \
+  --resource-arn <image build version arn> \
+  --state status=DELETED \
+  --execution-role <role arn> \
+  --include-resources amis=true,snapshots=true
+```
+
+Images in `FAILED` or `CANCELLED` state can only transition to `DELETED`.
+
+## Common errors
+
+| What you see | Likely cause | Fix |
+|---|---|---|
+| Policy runs but nothing is deleted | Fewer images than the COUNT value (it's a keep-count, not a delete-count), or all candidates are excluded | Check `list-lifecycle-execution-resources` - SKIPPED entries carry the reason |
+| AMIs survive while image resources disappear | `IncludeResources` missing `Amis`/`Snapshots` | Add them to the DELETE rule |
+| Lifecycle execution fails with access denied on EC2 actions | The AMIs lack the `CreatedBy: EC2 Image Builder` tag the managed policy's conditions require (they weren't distributed by Image Builder) | Only service-distributed AMIs are manageable with the managed policy; clean others up directly |
+| Tag-scoped policy matches nothing | The tags are on the AMI, not the Image Builder image resource - or the images came from manual runs, which skip the pipeline's `ImageTags` | Scheduled runs stamp `ImageTags` on the image resource automatically; tag manual builds with `aws imagebuilder tag-resource` |
+| Cross-account copies untouched | Lifecycle needs a role named `Ec2ImageBuilderCrossAccountLifecycleAccess` in each destination account | Create it there, trusting `imagebuilder.amazonaws.com` with `aws:SourceAccount` pinned to the distributing account and `aws:SourceArn` limited to `arn:*:imagebuilder:*:*:image/*/*/*` |
+
+## Cleanup
+
+1. Delete remaining image build versions - the one-off delete above with `--include-resources amis=true,snapshots=true` does image + AMI + snapshots per build. (Don't wait for the daily policy run to clean these up - the policy is deleted with the stack.)
+2. Delete the stack: `aws cloudformation delete-stack --stack-name lifecycle-sample`.
+3. If a build ran recently, the log groups can reappear after deletion while late log deliveries land - delete them again before redeploying the same stack name, or the deploy fails on the name conflict.

--- a/lifecycle/lifecycle-policy.yml
+++ b/lifecycle/lifecycle-policy.yml
@@ -1,0 +1,192 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >
+  EC2 Image Builder lifecycle management: a minimal pipeline whose output
+  images are cleaned up automatically by a lifecycle policy - keeping the
+  newest builds per recipe version and deleting the rest, AMIs and snapshots
+  included. The policies/ directory holds more policy shapes for the CLI.
+
+Resources:
+  # The role lifecycle actions run as. The managed policy scopes EC2 image
+  # and snapshot actions to resources tagged CreatedBy: EC2 Image Builder -
+  # the tag the service adds at distribution - so the role can't touch AMIs
+  # the service didn't build.
+  LifecycleExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - imagebuilder.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/EC2ImageBuilderLifecycleExecutionPolicy'
+
+  # Keeps the 3 newest images per recipe version and deletes everything
+  # older - including the distributed AMIs and their snapshots.
+  KeepNewestThree:
+    Type: AWS::ImageBuilder::LifecyclePolicy
+    Properties:
+      Name: lifecycle-sample-keep-newest-three
+      Description: Keep the 3 newest images per recipe version, delete the rest
+      Status: ENABLED
+      ExecutionRole: !GetAtt LifecycleExecutionRole.Arn
+      ResourceType: AMI_IMAGE
+      PolicyDetails:
+        - Action:
+            Type: DELETE
+            # Without this, only the Image Builder image resource is deleted;
+            # the AMI and snapshots stay behind and keep billing.
+            IncludeResources:
+              Amis: true
+              Snapshots: true
+          Filter:
+            # For COUNT, Value is the number of resources to keep on hand.
+            Type: COUNT
+            Value: 3
+          ExclusionRules:
+            # Tag any image resource with this to pin it past the policy.
+            TagMap:
+              LifecyclePin: retain
+      ResourceSelection:
+        Recipes:
+          # x wildcards resolve at execution time, so recipe versions created
+          # after the policy are covered.
+          - Name: lifecycle-sample
+            SemanticVersion: x.x.x
+
+  # ---------------------------------------------------------------------
+  # A minimal pipeline that produces the images the policy manages. The
+  # build is intentionally trivial - the sample is about what happens to
+  # images after they're built.
+  # ---------------------------------------------------------------------
+
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+      Path: /executionServiceEC2Role/
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /executionServiceEC2Role/
+      Roles:
+        - !Ref InstanceRole
+
+  BuildMarkerComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: lifecycle-sample-marker
+      # Creating a component needs a concrete version (x wildcards are for
+      # references). The service increments the build number behind the same
+      # version when the document changes, and the recipe's LatestVersion
+      # reference picks that up.
+      Version: 1.0.0
+      Platform: Linux
+      Description: Stamps the build date into the image.
+      Data: |
+        name: lifecycle-sample-marker
+        description: Stamps the build date into the image.
+        schemaVersion: 1.0
+        phases:
+          - name: build
+            steps:
+              - name: StampBuildDate
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - date -u '+%Y-%m-%dT%H:%M:%SZ' > /etc/lifecycle-sample-build
+
+  ImageRecipe:
+    Type: AWS::ImageBuilder::ImageRecipe
+    Properties:
+      # The lifecycle policy above selects images by this recipe name.
+      Name: lifecycle-sample
+      Version: 1.0.x
+      ParentImage: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/amazon-linux-2023-x86/x.x.x'
+      Components:
+        - ComponentArn: !GetAtt BuildMarkerComponent.LatestVersion.Arn
+
+  InfrastructureConfiguration:
+    Type: AWS::ImageBuilder::InfrastructureConfiguration
+    Properties:
+      Name: lifecycle-sample
+      InstanceProfileName: !Ref InstanceProfile
+      InstanceTypes:
+        - t3.medium
+      InstanceMetadataOptions:
+        HttpTokens: required
+      # Build instances launch in the account's default VPC. Without a
+      # default VPC, set SubnetId and SecurityGroupIds here.
+
+  BuildLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/lifecycle-sample
+      RetentionInDays: 7
+
+  PipelineLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/pipeline/lifecycle-sample
+      RetentionInDays: 7
+
+  ImagePipeline:
+    Type: AWS::ImageBuilder::ImagePipeline
+    Properties:
+      Name: lifecycle-sample
+      Description: >-
+        Produces the images that the lifecycle-sample policies manage.
+      ImageRecipeArn: !Ref ImageRecipe
+      InfrastructureConfigurationArn: !Ref InfrastructureConfiguration
+      LoggingConfiguration:
+        ImageLogGroupName: !Ref BuildLogGroup
+        PipelineLogGroupName: !Ref PipelineLogGroup
+      # Stamped onto the image resource on each scheduled run - the tags
+      # that policies/progressive-age.json's tagMap selection matches on.
+      # Manually started builds don't apply these; tag those images with
+      # 'aws imagebuilder tag-resource' (see the README's Testing steps).
+      ImageTags:
+        LifecycleGroup: lifecycle-sample
+      # Weekly, so retention has something to retire. EXPRESSION_MATCH_ONLY
+      # builds every cycle regardless of dependency updates.
+      Schedule:
+        ScheduleExpression: cron(0 9 ? * mon *)
+        PipelineExecutionStartCondition: EXPRESSION_MATCH_ONLY
+
+Outputs:
+  ImagePipelineArn:
+    Description: >-
+      ARN of the image pipeline. Start a build with 'aws imagebuilder
+      start-image-pipeline-execution --image-pipeline-arn <this value>'.
+    Value: !Ref ImagePipeline
+  LifecyclePolicyArn:
+    Description: The count-based lifecycle policy managing this pipeline's images.
+    Value: !Ref KeepNewestThree
+  LifecycleExecutionRoleArn:
+    Description: >-
+      Execution role for lifecycle actions - also usable with 'aws
+      imagebuilder start-resource-state-update' for one-off cleanup.
+    Value: !GetAtt LifecycleExecutionRole.Arn

--- a/lifecycle/policies/guarded-delete.json
+++ b/lifecycle/policies/guarded-delete.json
@@ -1,0 +1,50 @@
+{
+  "name": "guarded-delete",
+  "description": "Delete year-old images unless they are still in use or pinned",
+  "status": "ENABLED",
+  "executionRole": "arn:aws:iam::111122223333:role/LifecycleExecutionRole",
+  "resourceType": "AMI_IMAGE",
+  "policyDetails": [
+    {
+      "action": {
+        "type": "DELETE",
+        "includeResources": {
+          "amis": true,
+          "snapshots": true
+        }
+      },
+      "filter": {
+        "type": "AGE",
+        "value": 1,
+        "unit": "YEARS",
+        "retainAtLeast": 3
+      },
+      "exclusionRules": {
+        "tagMap": {
+          "LifecyclePin": "retain"
+        },
+        "amis": {
+          "isPublic": true,
+          "sharedAccounts": [
+            "444455556666"
+          ],
+          "lastLaunched": {
+            "value": 30,
+            "unit": "DAYS"
+          },
+          "regions": [
+            "us-east-1"
+          ],
+          "tagMap": {
+            "Environment": "production"
+          }
+        }
+      }
+    }
+  ],
+  "resourceSelection": {
+    "tagMap": {
+      "LifecycleGroup": "lifecycle-sample"
+    }
+  }
+}

--- a/lifecycle/policies/keep-last-n.json
+++ b/lifecycle/policies/keep-last-n.json
@@ -1,0 +1,30 @@
+{
+  "name": "keep-last-n",
+  "description": "Keep the 5 newest images per recipe version",
+  "status": "ENABLED",
+  "executionRole": "arn:aws:iam::111122223333:role/LifecycleExecutionRole",
+  "resourceType": "AMI_IMAGE",
+  "policyDetails": [
+    {
+      "action": {
+        "type": "DELETE",
+        "includeResources": {
+          "amis": true,
+          "snapshots": true
+        }
+      },
+      "filter": {
+        "type": "COUNT",
+        "value": 5
+      }
+    }
+  ],
+  "resourceSelection": {
+    "recipes": [
+      {
+        "name": "my-recipe",
+        "semanticVersion": "x.x.x"
+      }
+    ]
+  }
+}

--- a/lifecycle/policies/progressive-age.json
+++ b/lifecycle/policies/progressive-age.json
@@ -1,0 +1,55 @@
+{
+  "name": "progressive-age",
+  "description": "Deprecate at 90 days, disable at 120, delete at 180 - keeping at least 2",
+  "status": "ENABLED",
+  "executionRole": "arn:aws:iam::111122223333:role/LifecycleExecutionRole",
+  "resourceType": "AMI_IMAGE",
+  "policyDetails": [
+    {
+      "action": {
+        "type": "DEPRECATE",
+        "includeResources": {
+          "amis": true
+        }
+      },
+      "filter": {
+        "type": "AGE",
+        "value": 90,
+        "unit": "DAYS"
+      }
+    },
+    {
+      "action": {
+        "type": "DISABLE",
+        "includeResources": {
+          "amis": true
+        }
+      },
+      "filter": {
+        "type": "AGE",
+        "value": 120,
+        "unit": "DAYS"
+      }
+    },
+    {
+      "action": {
+        "type": "DELETE",
+        "includeResources": {
+          "amis": true,
+          "snapshots": true
+        }
+      },
+      "filter": {
+        "type": "AGE",
+        "value": 180,
+        "unit": "DAYS",
+        "retainAtLeast": 2
+      }
+    }
+  ],
+  "resourceSelection": {
+    "tagMap": {
+      "LifecycleGroup": "lifecycle-sample"
+    }
+  }
+}


### PR DESCRIPTION
Adds a full end-to-end sample of lifecycle policies working in a few cases, alongside image pipeline tagging on scheduled pipeline runs.

# Description

<!-- What does this PR change, and why? If it fixes an issue, link it. -->

## Checklist

- [X] I deployed this sample in my own account and it created AND deleted cleanly (no leftover AMIs, snapshots, or non-empty buckets beyond what the README documents)
- [X] The README covers prerequisites, deployment, and cleanup for what I changed
- [X] No account IDs, ARNs from real accounts, or credentials anywhere in the change - including test data
- [X] If this adds a sample, it's listed in the root README index

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
