### PR TITLE
Add a Terraform variant of the cross-account distribution sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amazon EC2 Image Builder Samples
 
-Working samples for [Amazon EC2 Image Builder](https://aws.amazon.com/image-builder/): CloudFormation templates, CDK applications, and AWSTOE components. Each sample is self-contained with its own README.
+Working samples for [Amazon EC2 Image Builder](https://aws.amazon.com/image-builder/): CloudFormation templates, CDK applications, Terraform modules, and AWSTOE components. Each sample is self-contained with its own README.
 
 This repository is maintained by the EC2 Image Builder service team. Samples are provided as-is - we review issues and pull requests on a best-effort basis.
 
@@ -26,6 +26,7 @@ From there:
 | [golden-ami-pipeline](golden-ami-pipeline/) | The golden-AMI loop end to end: monthly patching from an SSM-parameter base, launch template promotion, an instance refresh that automatically moves the running Auto Scaling group onto each new AMI, and build events turned into readable pass/fail notifications |
 | [networking/private-vpc-builds](networking/private-vpc-builds/) | Builds in an isolated VPC with no internet - the endpoints a build needs, the S3 bucket allowlist, and a common-errors table mapping each failure to its missing endpoint (CloudFormation and CDK) |
 | [lifecycle](lifecycle/) | Automatic cleanup of old images, AMIs, and snapshots: the retention model explained, a working count-based policy, and ready-to-use policy documents for progressive age-based and guarded deletion |
+| [Terraform/cross-account-amis](Terraform/cross-account-amis/) | The cross-account distribution sample in Terraform - component documents via file(), content-hash versioning, and the two-account apply flow |
 
 ### CloudFormation - Linux AMIs
 

--- a/Terraform/cross-account-amis/.gitignore
+++ b/Terraform/cross-account-amis/.gitignore
@@ -1,0 +1,12 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.backup
+*.tfvars
+*.tfvars.json
+*.tfplan
+crash.log
+crash.*.log
+override.tf
+*_override.tf
+.terraform.tfstate.lock.info

--- a/Terraform/cross-account-amis/README.md
+++ b/Terraform/cross-account-amis/README.md
@@ -1,0 +1,84 @@
+# Cross-account AMI distribution (Terraform)
+
+The Terraform twin of the CloudFormation [cross-account distribution sample](../../distribution/cross-account-amis/): a source account builds an Amazon Linux 2023 image encrypted with a customer managed KMS key and distributes an owned copy of the AMI to target accounts, with each account's AMI ID published to an SSM parameter in that account. The distribution mechanics - the key policy, the fixed-name target role, the share-vs-copy distinction - are documented in that sample's README and apply here unchanged. This README covers what's Terraform-specific.
+
+Two root modules, applied with each account's own credentials:
+
+- [source-account/](source-account/) - the pipeline, KMS key, and distribution configuration.
+- [target-account/](target-account/) - the `EC2ImageBuilderDistributionCrossAccountRole`, deployed once per target account.
+
+Running both from a single apply with [provider aliases](https://developer.hashicorp.com/terraform/language/providers/configuration#alias-multiple-provider-configurations) works too; separate modules keep the sample free of assumptions about your cross-account credential setup.
+
+## Terraform-specific patterns
+
+**Component documents load with `file()`.** It passes the document through byte-for-byte with no interpolation - multi-line commands survive untouched and shell `$` syntax needs no escaping. If you need variables inside a document, `templatefile()` works but every literal `${...}` the shell should see must be escaped as `$${...}`.
+
+**Versions are content-hash-derived.** A component or recipe is registered under a fixed name + version pair, so the sample derives a numeric patch version from a content hash:
+
+```hcl
+component_version = "1.0.${parseint(substr(sha256(local.component_document), 0, 4), 16)}"
+```
+
+The version changes when the hashed inputs change, `create_before_destroy` makes the replacement safe (the new name+version pair differs from the old one), and the pipeline follows the new recipe ARN with an in-place update. To retain superseded component versions instead of deleting them, set `skip_destroy = true` on the component. Recipes are immutable, so the recipe version's hash must cover every recipe-shaping argument - the sample hashes the component version and parent image name; extend it if you change other arguments, or bump the version by hand. Wildcard references (the recipe's `x.x.x` parent image) resolve to the latest release at build time.
+
+## Cost
+
+Each run bills one EC2 build instance and one test instance for the build duration (typically 15 to 30 minutes) at standard EC2 rates, plus AMI/snapshot storage in the source account and every target account (copies are full, owned AMIs). The KMS key bills at the standard monthly key rate and enters a 7-day deletion window on destroy.
+
+## Prerequisites
+
+- Terraform >= 1.5 and AWS provider >= 6.0.
+- Credentials for the source account and each target account.
+- A default VPC in the source account's build region (or set `subnet_id`/`security_group_ids` on the infrastructure configuration).
+
+## Deploy
+
+Order matters: the target-account role must exist before the pipeline's first run, and the source module's key ARN is an input to the target module.
+
+1. Source account:
+
+```shell
+cd source-account
+terraform init
+terraform apply -var 'target_account_ids=["<target account id>"]'
+```
+
+2. Each target account (with that account's credentials):
+
+```shell
+cd ../target-account
+terraform init
+terraform apply \
+  -var 'source_account_id=<source account id>' \
+  -var 'source_kms_key_arn=<kms_key_arn output from step 1>'
+```
+
+Keep `source_account_id` pinned to the one account that runs the pipeline: the role can copy AMIs into this account and write its SSM parameters, so don't widen its trust to `*` or an organization path.
+
+If the target account already has an `EC2ImageBuilderDistributionCrossAccountRole` (the name is fixed by the service - one per account), reuse it: make sure its trust covers your source account and its inline policy covers this key ARN, and skip the target module.
+
+3. Run the pipeline (source account):
+
+```shell
+aws imagebuilder start-image-pipeline-execution \
+  --image-pipeline-arn "$(terraform -chdir=../source-account output -raw image_pipeline_arn)"
+```
+
+## Testing
+
+The build typically takes 15 to 30 minutes. When the image reaches `AVAILABLE`, distribution copies the AMI to each target account and writes the SSM parameters:
+
+- Source account: `/imagebuilder/cross-account-sample-tf/source-ami` holds the source AMI ID.
+- Target account: `/imagebuilder/cross-account-sample-tf/target-ami` holds that account's own copy's AMI ID - written in the target account, through the distribution role.
+- In the target account, `aws ec2 describe-images --owners self --filters "Name=name,Values=cross-account-sample-tf-*"` shows the owned copy, and its snapshot reports `Encrypted: true` with the source account's key.
+
+The [CloudFormation sample's README](../../distribution/cross-account-amis/README.md#common-errors) has the common-errors table - the failure modes are identical.
+
+## Cleanup
+
+Distribution outputs aren't Terraform resources, so both accounts need manual steps before destroy:
+
+1. In each target account: deregister the `cross-account-sample-tf-*` AMIs, delete their snapshots, and delete the `/imagebuilder/cross-account-sample-tf/target-ami` parameter.
+2. In the source account: delete the Image Builder image build versions (`aws imagebuilder delete-image`), deregister the source AMIs and delete their snapshots, and delete the `/imagebuilder/cross-account-sample-tf/source-ami` parameter.
+3. `terraform destroy` in target-account, then in source-account (the key enters its 7-day deletion window - anything still encrypted with it becomes unrecoverable after that, which is why the AMIs go first).
+4. If a build ran recently, the log group can reappear after destroy while late log deliveries land - delete it again before re-applying, or the apply fails on the name conflict.

--- a/Terraform/cross-account-amis/source-account/components/build-info.yml
+++ b/Terraform/cross-account-amis/source-account/components/build-info.yml
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+name: cross-account-sample-tf-build-info
+description: Writes a marker file used to verify the AMI in target accounts.
+schemaVersion: 1.0
+phases:
+  - name: build
+    steps:
+      - name: WriteBuildInfo
+        action: ExecuteBash
+        inputs:
+          commands:
+            - echo "Built by the EC2 Image Builder cross-account distribution sample (Terraform)" > /etc/cross-account-sample-release

--- a/Terraform/cross-account-amis/source-account/main.tf
+++ b/Terraform/cross-account-amis/source-account/main.tf
@@ -1,0 +1,256 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+data "aws_partition" "current" {}
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  component_document = file("${path.module}/components/build-info.yml")
+  parent_image_name  = "amazon-linux-2023-x86"
+
+  # Components and recipes register under a fixed name + version pair, so
+  # versions derive a numeric patch from a content hash: change the inputs
+  # and the version changes with them. Recipes are immutable, so the recipe
+  # hash must cover every recipe-shaping input here - extend it if you
+  # change other arguments, or bump the version by hand.
+  component_version = "1.0.${parseint(substr(sha256(local.component_document), 0, 4), 16)}"
+  recipe_version    = "1.0.${parseint(substr(sha256(jsonencode([local.component_version, local.parent_image_name])), 0, 4), 16)}"
+}
+
+# ---------------------------------------------------------------------------
+# Encrypts the image and every copy distributed to the target accounts. A
+# customer managed key is required here: target accounts can never be granted
+# use of this account's EBS default key.
+# ---------------------------------------------------------------------------
+resource "aws_kms_key" "image_encryption" {
+  description         = "Encrypts AMIs built by the cross-account distribution sample (Terraform)"
+  enable_key_rotation = true
+  # Shortest deletion window KMS allows (7-30 days), so destroy releases the
+  # key as quickly as possible.
+  deletion_window_in_days = 7
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # Keeps this account in control of the key: IAM policies in the
+      # account (including the Image Builder service-linked role's) can
+      # grant access, and the key can't become unmanageable.
+      {
+        Sid       = "EnableIAMUserPermissions"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action    = "kms:*"
+        Resource  = "*"
+      },
+      # The build path: the build instance reads and writes EBS volumes
+      # encrypted with this key.
+      {
+        Sid       = "AllowBuildInstanceUseOfTheKey"
+        Effect    = "Allow"
+        Principal = { AWS = aws_iam_role.instance.arn }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+      # Grants each target ACCOUNT use of the key - deliberately wider than
+      # the distribution role, because copies stay encrypted with this key,
+      # so every principal that launches instances from a copy needs it too.
+      {
+        Sid       = "AllowTargetAccountUseOfTheKey"
+        Effect    = "Allow"
+        Principal = { AWS = [for id in var.target_account_ids : "arn:${data.aws_partition.current.partition}:iam::${id}:root"] }
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey",
+        ]
+        Resource = "*"
+      },
+      # EC2 and EBS in the target accounts create grants on this key when
+      # instances launch from the copied AMI. GrantIsForAWSResource limits
+      # that to grants AWS services create on the caller's behalf - removing
+      # the condition lets any principal in a target account hand out
+      # arbitrary grants on this key.
+      {
+        Sid       = "AllowTargetAccountGrantsForAWSResources"
+        Effect    = "Allow"
+        Principal = { AWS = [for id in var.target_account_ids : "arn:${data.aws_partition.current.partition}:iam::${id}:root"] }
+        Action = [
+          "kms:CreateGrant",
+          "kms:ListGrants",
+          "kms:RevokeGrant",
+        ]
+        Resource = "*"
+        Condition = {
+          Bool = { "kms:GrantIsForAWSResource" = true }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_kms_alias" "image_encryption" {
+  name          = "alias/cross-account-sample-tf"
+  target_key_id = aws_kms_key.image_encryption.key_id
+}
+
+# ---------------------------------------------------------------------------
+# The build instance profile. The two managed policies are the supported
+# baseline for Image Builder build instances.
+# ---------------------------------------------------------------------------
+resource "aws_iam_role" "instance" {
+  name_prefix = "cross-account-sample-tf-"
+  path        = "/executionServiceEC2Role/"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ec2.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_core" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "imagebuilder_instance" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder"
+}
+
+resource "aws_iam_instance_profile" "instance" {
+  name_prefix = "cross-account-sample-tf-"
+  path        = "/executionServiceEC2Role/"
+  role        = aws_iam_role.instance.name
+}
+
+# ---------------------------------------------------------------------------
+# Build resources.
+# ---------------------------------------------------------------------------
+resource "aws_cloudwatch_log_group" "build" {
+  name              = "/aws/imagebuilder/cross-account-sample-tf"
+  retention_in_days = 7
+}
+
+resource "aws_imagebuilder_component" "build_info" {
+  name     = "cross-account-sample-tf-build-info"
+  version  = local.component_version
+  platform = "Linux"
+  # file() does no interpolation, so component documents keep their shell
+  # syntax as written - templatefile() would require escaping every $ sign.
+  data = local.component_document
+
+  # A version bump replaces the component; creating the new one first keeps
+  # the recipe update atomic - the content hash gives the replacement a
+  # different version.
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_imagebuilder_image_recipe" "this" {
+  name    = "cross-account-sample-tf"
+  version = local.recipe_version
+  # x.x.x resolves to the latest release of the managed parent image at
+  # build time, so each build starts from the current base release.
+  parent_image = "arn:${data.aws_partition.current.partition}:imagebuilder:${data.aws_region.current.region}:aws:image/${local.parent_image_name}/x.x.x"
+
+  component {
+    component_arn = aws_imagebuilder_component.build_info.arn
+  }
+
+  # The explicit root mapping is what ties the image to the customer managed
+  # key. Omitting it silently encrypts the root volume with the account's
+  # EBS default key instead of this key, and cross-account distribution of
+  # the AMI then fails.
+  block_device_mapping {
+    device_name = "/dev/xvda"
+
+    ebs {
+      delete_on_termination = true
+      encrypted             = true
+      kms_key_id            = aws_kms_key.image_encryption.arn
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_imagebuilder_infrastructure_configuration" "this" {
+  name                  = "cross-account-sample-tf"
+  instance_profile_name = aws_iam_instance_profile.instance.name
+
+  instance_metadata_options {
+    http_tokens = "required"
+  }
+  # Build instances launch in the account's default VPC. Without a default
+  # VPC, set subnet_id and security_group_ids here.
+}
+
+resource "aws_imagebuilder_distribution_configuration" "this" {
+  name = "cross-account-sample-tf"
+
+  distribution {
+    region = data.aws_region.current.region
+
+    ami_distribution_configuration {
+      name = "cross-account-sample-tf-{{ imagebuilder:buildDate }}"
+      # target_account_ids copies the AMI: each target account gets its own
+      # AMI and snapshots that it fully owns. This is distinct from
+      # launch_permission (deliberately omitted here), which would let
+      # target accounts launch the source-owned AMI instead.
+      target_account_ids = var.target_account_ids
+      # Encrypts every copy with the customer managed key. Without this,
+      # copies fall back to the EBS default key and target accounts can't
+      # use them. The full key ARN is required: the target account resolves
+      # this value during its copy, and a bare key ID only resolves in the
+      # key's own account.
+      kms_key_id = aws_kms_key.image_encryption.arn
+    }
+
+    # Image Builder writes these parameters after distribution, each in the
+    # account named by the entry. They aren't Terraform resources, so
+    # destroy doesn't delete them (see the README cleanup).
+    # No ami_account_id: written in this (source) account with the source
+    # AMI ID.
+    ssm_parameter_configuration {
+      parameter_name = "/imagebuilder/cross-account-sample-tf/source-ami"
+      data_type      = "aws:ec2:image"
+    }
+
+    # ami_account_id picks WHICH account's copied AMI ID lands in the
+    # parameter, and the parameter is written in that account through its
+    # EC2ImageBuilderDistributionCrossAccountRole. One entry per target
+    # account - this covers the first; duplicate it for others.
+    ssm_parameter_configuration {
+      parameter_name = "/imagebuilder/cross-account-sample-tf/target-ami"
+      data_type      = "aws:ec2:image"
+      ami_account_id = var.target_account_ids[0]
+    }
+  }
+}
+
+# No schedule: the pipeline is run manually (see the README) so the
+# target-account roles can be in place before the first distribution.
+resource "aws_imagebuilder_image_pipeline" "this" {
+  name                             = "cross-account-sample-tf"
+  image_recipe_arn                 = aws_imagebuilder_image_recipe.this.arn
+  infrastructure_configuration_arn = aws_imagebuilder_infrastructure_configuration.this.arn
+  distribution_configuration_arn   = aws_imagebuilder_distribution_configuration.this.arn
+}

--- a/Terraform/cross-account-amis/source-account/outputs.tf
+++ b/Terraform/cross-account-amis/source-account/outputs.tf
@@ -1,0 +1,11 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+output "kms_key_arn" {
+  description = "Pass this to the target-account module as source_kms_key_arn."
+  value       = aws_kms_key.image_encryption.arn
+}
+
+output "image_pipeline_arn" {
+  description = "Run this pipeline once every target-account role is deployed."
+  value       = aws_imagebuilder_image_pipeline.this.arn
+}

--- a/Terraform/cross-account-amis/source-account/variables.tf
+++ b/Terraform/cross-account-amis/source-account/variables.tf
@@ -1,0 +1,10 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+variable "target_account_ids" {
+  description = "Account IDs that receive their own copy of the output AMI. Each account needs the distribution role from ../target-account before the pipeline runs."
+  type        = list(string)
+  validation {
+    condition     = length(var.target_account_ids) > 0 && alltrue([for id in var.target_account_ids : can(regex("^\\d{12}$", id))])
+    error_message = "Each entry must be a 12-digit AWS account ID."
+  }
+}

--- a/Terraform/cross-account-amis/source-account/versions.tf
+++ b/Terraform/cross-account-amis/source-account/versions.tf
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {}

--- a/Terraform/cross-account-amis/target-account/main.tf
+++ b/Terraform/cross-account-amis/target-account/main.tf
@@ -1,0 +1,83 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+
+# Image Builder looks this role up by its fixed, service-defined name when
+# it distributes to this account - a role with any other name is never
+# assumed, and distribution fails as if no role existed.
+resource "aws_iam_role" "distribution" {
+  name = "EC2ImageBuilderDistributionCrossAccountRole"
+
+  # Image Builder assumes this role FROM the source account, so the trusted
+  # principal is the source account root - not the imagebuilder.amazonaws.com
+  # service principal. Widening this to '*' or an organization path lets
+  # every matching account push AMIs into this account and write its SSM
+  # parameters.
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { AWS = "arn:${data.aws_partition.current.partition}:iam::${var.source_account_id}:root" }
+        Action    = "sts:AssumeRole"
+      },
+    ]
+  })
+}
+
+# The EC2 side of receiving a copy: CopyImage and the related EC2 actions
+# the service performs in this account.
+resource "aws_iam_role_policy_attachment" "cross_account_distribution" {
+  role       = aws_iam_role.distribution.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/Ec2ImageBuilderCrossAccountDistributionAccess"
+}
+
+resource "aws_iam_role_policy" "additions" {
+  name = "CrossAccountDistributionAdditions"
+  role = aws_iam_role.distribution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # Decrypts the source snapshot and re-encrypts this account's copy.
+      # Without it, distribution fails with a KMS AccessDenied (typically on
+      # kms:CreateGrant or kms:DescribeKey) and no AMI appears in this
+      # account.
+      {
+        Sid    = "UseSourceKmsKey"
+        Effect = "Allow"
+        Action = [
+          "kms:Encrypt",
+          "kms:Decrypt",
+          "kms:ReEncrypt*",
+          "kms:GenerateDataKey*",
+          "kms:DescribeKey",
+          "kms:CreateGrant",
+          "kms:ListGrants",
+          "kms:RevokeGrant",
+        ]
+        Resource = var.source_kms_key_arn
+      },
+      # Writes the AMI ID parameter for this account's copy. Without it, the
+      # AMI still arrives but the SSM parameter write fails and the
+      # parameter never appears in this account.
+      {
+        Sid      = "WriteImageBuilderParameters"
+        Effect   = "Allow"
+        Action   = ["ssm:PutParameter"]
+        Resource = "arn:${data.aws_partition.current.partition}:ssm:*:${data.aws_caller_identity.current.account_id}:parameter/imagebuilder/*"
+      },
+      # The aws:ec2:image parameter data type validates the AMI ID on write,
+      # which requires ec2:DescribeImages. The managed policy above also
+      # grants it; this mirrors the documented role setup.
+      {
+        Sid      = "ValidateAmiParameters"
+        Effect   = "Allow"
+        Action   = ["ec2:DescribeImages"]
+        Resource = "*"
+      },
+    ]
+  })
+}

--- a/Terraform/cross-account-amis/target-account/outputs.tf
+++ b/Terraform/cross-account-amis/target-account/outputs.tf
@@ -1,0 +1,6 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+output "distribution_role_arn" {
+  description = "Role Image Builder assumes from the source account."
+  value       = aws_iam_role.distribution.arn
+}

--- a/Terraform/cross-account-amis/target-account/variables.tf
+++ b/Terraform/cross-account-amis/target-account/variables.tf
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+variable "source_account_id" {
+  description = "The account that runs the Image Builder pipeline. Only this account can assume the distribution role - keep it pinned to the single source account you control."
+  type        = string
+  validation {
+    condition     = can(regex("^\\d{12}$", var.source_account_id))
+    error_message = "Must be a 12-digit AWS account ID."
+  }
+}
+
+variable "source_kms_key_arn" {
+  description = "ARN of the source account's customer managed key that encrypts the AMI (the kms_key_arn output of the source-account module)."
+  type        = string
+  validation {
+    condition     = can(regex("^arn:aws[a-zA-Z-]*:kms:[a-z0-9-]+:\\d{12}:key/.+$", var.source_kms_key_arn))
+    error_message = "Must be a KMS key ARN."
+  }
+}

--- a/Terraform/cross-account-amis/target-account/versions.tf
+++ b/Terraform/cross-account-amis/target-account/versions.tf
@@ -1,0 +1,13 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {}


### PR DESCRIPTION
# Description

Provides a complete and correct Terraform example of using Image Builder along with recent Image Builder IAC experience improvements - a copy of the 'cross account distribution' sample but with Terraform.

The content hash stuff can be removed pending these PRs in Terraform:
* https://github.com/hashicorp/terraform-provider-aws/pull/45288
* https://github.com/hashicorp/terraform-provider-aws/pull/45366

## Checklist

- [X] I deployed this sample in my own account and it created AND deleted cleanly (no leftover AMIs, snapshots, or non-empty buckets beyond what the README documents)
- [X] The README covers prerequisites, deployment, and cleanup for what I changed
- [X] No account IDs, ARNs from real accounts, or credentials anywhere in the change - including test data
- [X] If this adds a sample, it's listed in the root README index

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
