### PR TITLE
Add an image approval gate sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ From there:
 | [networking/private-vpc-builds](networking/private-vpc-builds/) | Builds in an isolated VPC with no internet - the endpoints a build needs, the S3 bucket allowlist, and a common-errors table mapping each failure to its missing endpoint (CloudFormation and CDK) |
 | [lifecycle](lifecycle/) | Automatic cleanup of old images, AMIs, and snapshots: the retention model explained, a working count-based policy, and ready-to-use policy documents for progressive age-based and guarded deletion |
 | [Terraform/cross-account-amis](Terraform/cross-account-amis/) | The cross-account distribution sample in Terraform - component documents via file(), content-hash versioning, and the two-account apply flow |
+| [workflows/approval-gate](workflows/approval-gate/) | A build workflow that pauses for human approval before the image is created - WaitForAction, an SNS approval request, and the RESUME/STOP response flow |
 
 ### CloudFormation - Linux AMIs
 

--- a/workflows/approval-gate/README.md
+++ b/workflows/approval-gate/README.md
@@ -1,0 +1,70 @@
+# Approve every image before it exists
+
+A standard pipeline builds and registers the image in one motion. This sample inserts a gate: a custom build workflow pauses after components run, notifies an SNS topic, and waits for an explicit approval - with the build instance still running, so the approver can inspect exactly what's about to become the image. Everything lives in one CloudFormation template: [approval-gate.yml](approval-gate.yml).
+
+## How the gate works
+
+1. The pipeline runs the custom build workflow instead of the default: launch, run components, then a `WaitForAction` step named `ApproveImage`.
+2. The step publishes an approval request to the topic and pauses. The message carries the image ARN and the step execution ID - the two arguments the response command needs - plus the workflow's payload text as `customPayload`. It also emits an `EC2 Image Builder Workflow Step Waiting` event on the default EventBridge bus, and can invoke a Lambda directly through its `lambdaFunctionName` input - the [accelerated-build-asg sample](../../CDK/Linux/accelerated-build-asg/) drives its whole build that way.
+3. The approver responds:
+
+```shell
+aws imagebuilder send-workflow-step-action \
+  --step-execution-id <from the notification or list-workflow-step-executions> \
+  --image-build-version-arn <the build's ARN> \
+  --action RESUME \
+  --reason "Looks good"
+```
+
+The console offers the same controls: the Images page's **Waiting for action** tab lists every paused step, with resume and stop actions.
+
+`RESUME` continues to `CreateImage`; `STOP` ends the workflow and the build fails. If nobody responds, the step times out - 3 days by default, up to 7 via `timeoutSeconds` on the step - and the build fails.
+
+Details worth knowing:
+
+- **The notification publishes as the execution role**, so the role carries `sns:Publish` and the topic key's `kms` grant - custom workflows require an execution role either way.
+- **The `reason` travels.** Whatever the approver passes with `RESUME` is readable by later steps as `$.stepOutputs.ApproveImage.reason` - a lightweight channel for passing data into the rest of the workflow. It's free text from the approver, so don't splice it into shell commands.
+- **Approval is an IAM permission.** Anyone who can call `imagebuilder:SendWorkflowStepAction` on the build can respond - scope that action to your approver group if the gate needs real separation of duties. CloudTrail records each response with the caller and reason.
+- **The pipeline's `Workflows` property replaces the defaults.** This pipeline names only the build workflow, so the test stage is skipped. To keep tests, add a test workflow (Amazon's managed `test-image` or your own) alongside it.
+
+## Cost
+
+- The build bills a t3.medium for the build duration - including the whole time the workflow waits for approval, since the instance stays running. A forgotten build bills until the step times out (3 days by default).
+- Each output AMI's snapshot bills until you deregister the AMI and delete the snapshot.
+- The KMS key bills at the standard monthly key rate until deleted.
+
+## Prerequisites
+
+- A default VPC in the deployment region (or set `SubnetId`/`SecurityGroupIds` on the infrastructure configuration).
+- AWS CLI with permissions to deploy CloudFormation stacks with IAM resources.
+
+## Deploy
+
+```shell
+aws cloudformation deploy \
+  --template-file approval-gate.yml \
+  --stack-name approval-gate \
+  --parameter-overrides NotificationEmail=you@example.com \
+  --capabilities CAPABILITY_IAM
+```
+
+## Testing
+
+1. Start a build: `aws imagebuilder start-image-pipeline-execution --image-pipeline-arn <ImagePipelineArn output>`.
+2. After components finish (about 10 minutes), the approval request arrives on the topic and the workflow step shows `WAITING`:
+
+```shell
+aws imagebuilder list-workflow-executions --image-build-version-arn <build arn>
+aws imagebuilder list-workflow-step-executions --workflow-execution-id <from above>
+```
+
+3. Inspect the build instance if you like - find it on the launch step with `aws imagebuilder list-workflow-step-executions`; it stays alive and reachable through SSM while the step waits.
+4. Approve with `send-workflow-step-action --action RESUME` (above). The build continues to `AVAILABLE`.
+5. Run a second build and respond with `--action STOP`: the workflow ends, the build fails with the stop reason, and the build instance is cleaned up by rollback.
+
+## Cleanup
+
+1. Delete the image build versions (`aws imagebuilder delete-image --image-build-version-arn <arn>` per build).
+2. Deregister the `approval-gate-*` AMIs and delete their snapshots.
+3. Delete the stack: `aws cloudformation delete-stack --stack-name approval-gate`. The KMS key enters its 7-day deletion window.
+4. If a build ran recently, the log groups can reappear after deletion while late log deliveries land - delete them again before redeploying the same stack name, or the deploy fails on the name conflict.

--- a/workflows/approval-gate/approval-gate.yml
+++ b/workflows/approval-gate/approval-gate.yml
@@ -1,0 +1,289 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >
+  EC2 Image Builder approval gate: a custom build workflow that pauses before
+  creating the image. A WaitForAction step notifies an SNS topic and waits for
+  send-workflow-step-action RESUME or STOP, so a human (or an automated check)
+  approves every image while the build instance is still alive to inspect.
+
+Parameters:
+  NotificationEmail:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional email address to subscribe to the approval topic. Leave empty
+      to skip the subscription and read notifications from the topic through
+      other means.
+
+Conditions:
+  HasEmail: !Not [!Equals [!Ref NotificationEmail, '']]
+
+Resources:
+  # ---------------------------------------------------------------------
+  # The execution role. Required whenever custom workflows are attached.
+  # The managed policy covers the workflow actions, including SNS writes;
+  # the encrypted topic additionally needs the key grant, and the scoped
+  # sns:Publish keeps the delta explicit.
+  # ---------------------------------------------------------------------
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - imagebuilder.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2ImageBuilderExecutionPolicy'
+      Policies:
+        - PolicyName: ApprovalNotifications
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # The service publishes the WaitForAction notification as this
+              # role, so it needs the topic and its encryption key.
+              - Effect: Allow
+                Action:
+                  - sns:Publish
+                Resource:
+                  - !Ref ApprovalTopic
+              - Effect: Allow
+                Action:
+                  - kms:GenerateDataKey*
+                  - kms:Decrypt
+                Resource:
+                  - !GetAtt NotificationKey.Arn
+
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref InstanceRole
+
+  # ---------------------------------------------------------------------
+  # The approval topic. The WaitForAction step publishes here through the
+  # execution role; approvers reply with send-workflow-step-action.
+  # ---------------------------------------------------------------------
+  NotificationKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: Encrypts the approval-gate notification topic
+      EnableKeyRotation: true
+      PendingWindowInDays: 7
+      KeyPolicy:
+        Version: '2012-10-17'
+        Statement:
+          # Keeps the key manageable and lets same-account IAM policies -
+          # like the execution role's grant - take effect.
+          - Sid: EnableIAMUserPermissions
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+
+  ApprovalTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: approval-gate-notifications
+      KmsMasterKeyId: !GetAtt NotificationKey.Arn
+
+  EmailSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: HasEmail
+    Properties:
+      TopicArn: !Ref ApprovalTopic
+      Protocol: email
+      Endpoint: !Ref NotificationEmail
+
+  # ---------------------------------------------------------------------
+  # A minimal component so the recipe has something to build.
+  # ---------------------------------------------------------------------
+  BuildLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/approval-gate
+      RetentionInDays: 30
+
+  PipelineLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/pipeline/approval-gate
+      RetentionInDays: 30
+
+  BuildInfoComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: approval-gate-build-info
+      # Creating a component needs a concrete version (x wildcards are for
+      # references). The service increments the build number behind the same
+      # version when the document changes, and the recipe's LatestVersion
+      # reference picks that up.
+      Version: 1.0.0
+      Platform: Linux
+      Data: |
+        name: approval-gate-build-info
+        description: Writes build metadata into the image.
+        schemaVersion: 1.0
+        phases:
+          - name: build
+            steps:
+              - name: WriteBuildInfo
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - mkdir -p /opt/approval-gate
+                    - date -u '+Built on %Y-%m-%dT%H:%M:%SZ' > /opt/approval-gate/build-info.txt
+
+  ImageRecipe:
+    Type: AWS::ImageBuilder::ImageRecipe
+    Properties:
+      Name: approval-gate
+      # x auto-increments the build version, so updates that replace the
+      # recipe never collide with an existing name + version pair.
+      Version: 1.0.x
+      # x.x.x resolves to the latest release of the managed parent image at
+      # build time.
+      ParentImage: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/amazon-linux-2023-x86/x.x.x'
+      Components:
+        - ComponentArn: !GetAtt BuildInfoComponent.LatestVersion.Arn
+
+  InfrastructureConfiguration:
+    Type: AWS::ImageBuilder::InfrastructureConfiguration
+    Properties:
+      Name: approval-gate
+      InstanceProfileName: !Ref InstanceProfile
+      InstanceTypes:
+        - t3.medium
+      InstanceMetadataOptions:
+        HttpTokens: required
+      # Build instances launch in the account's default VPC. Without a
+      # default VPC, set SubnetId and SecurityGroupIds here.
+
+  # ---------------------------------------------------------------------
+  # The build workflow. The same shape as a standard build until the
+  # approval step: the workflow pauses with the build instance still
+  # running, so the approver can inspect it before the image is created.
+  # ---------------------------------------------------------------------
+  ApprovalWorkflow:
+    Type: AWS::ImageBuilder::Workflow
+    Properties:
+      Name: approval-gate-build
+      # Workflows version like components: concrete at creation, x wildcards
+      # when referencing.
+      Version: 1.0.0
+      Type: BUILD
+      Data: |
+        name: approval-gate-build
+        description: Build workflow that waits for approval before creating the image.
+        schemaVersion: 1.0
+
+        parameters:
+          - name: approvalTopicArn
+            type: string
+            description: SNS topic the approval request is published to.
+
+        steps:
+          - name: LaunchBuildInstance
+            action: LaunchInstance
+            onFailure: Abort
+            inputs:
+              waitFor: ssmAgent
+
+          - name: ApplyBuildComponents
+            action: ExecuteComponents
+            onFailure: Abort
+            inputs:
+              instanceId.$: "$.stepOutputs.LaunchBuildInstance.instanceId"
+
+          # Publishes to the topic and pauses (default 3 days, 7-day max via
+          # timeoutSeconds). The message carries the image ARN, the step
+          # execution ID, and this payload - see the README for the flow.
+          - name: ApproveImage
+            action: WaitForAction
+            onFailure: Abort
+            inputs:
+              snsTopicArn.$: "$.parameters.approvalTopicArn"
+              payload: 'Inspect the build instance for this step execution, then approve (RESUME) or reject (STOP) the image.'
+
+          - name: CreateOutputImage
+            action: CreateImage
+            onFailure: Abort
+            inputs:
+              instanceId.$: "$.stepOutputs.LaunchBuildInstance.instanceId"
+
+          - name: TerminateBuildInstance
+            action: TerminateInstance
+            onFailure: Continue
+            inputs:
+              instanceId.$: "$.stepOutputs.LaunchBuildInstance.instanceId"
+
+        outputs:
+          - name: ImageId
+            value: "$.stepOutputs.CreateOutputImage.imageId"
+
+  DistributionConfiguration:
+    Type: AWS::ImageBuilder::DistributionConfiguration
+    Properties:
+      Name: approval-gate
+      Distributions:
+        - Region: !Ref AWS::Region
+          AmiDistributionConfiguration:
+            Name: 'approval-gate-{{ imagebuilder:buildDate }}'
+
+  ImagePipeline:
+    Type: AWS::ImageBuilder::ImagePipeline
+    Properties:
+      Name: approval-gate
+      Description: Builds pause for approval before the image is created.
+      ImageRecipeArn: !Ref ImageRecipe
+      InfrastructureConfigurationArn: !Ref InfrastructureConfiguration
+      DistributionConfigurationArn: !Ref DistributionConfiguration
+      ExecutionRole: !GetAtt ExecutionRole.Arn
+      LoggingConfiguration:
+        ImageLogGroupName: !Ref BuildLogGroup
+        PipelineLogGroupName: !Ref PipelineLogGroup
+      # Setting Workflows replaces the defaults: only what's named here runs,
+      # so this pipeline runs the custom build workflow and skips the test stage.
+      Workflows:
+        - WorkflowArn: !GetAtt ApprovalWorkflow.Arn
+          Parameters:
+            - Name: approvalTopicArn
+              Value:
+                - !Ref ApprovalTopic
+
+Outputs:
+  ImagePipelineArn:
+    Description: >-
+      ARN of the image pipeline. Start a build with 'aws imagebuilder
+      start-image-pipeline-execution --image-pipeline-arn <this value>'.
+    Value: !Ref ImagePipeline
+  ApprovalTopicArn:
+    Description: The topic that receives approval requests.
+    Value: !Ref ApprovalTopic


### PR DESCRIPTION
# Description

Demonstrates using a custom workflow with a WaitForAction step to pause the build -> SNS message -> manual resume/stop.

## Checklist

- [X] I deployed this sample in my own account and it created AND deleted cleanly (no leftover AMIs, snapshots, or non-empty buckets beyond what the README documents)
- [X] The README covers prerequisites, deployment, and cleanup for what I changed
- [X] No account IDs, ARNs from real accounts, or credentials anywhere in the change - including test data
- [X] If this adds a sample, it's listed in the root README index

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
