### PR TITLE
Workflows sfn integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ From there:
 | [lifecycle](lifecycle/) | Automatic cleanup of old images, AMIs, and snapshots: the retention model explained, a working count-based policy, and ready-to-use policy documents for progressive age-based and guarded deletion |
 | [Terraform/cross-account-amis](Terraform/cross-account-amis/) | The cross-account distribution sample in Terraform - component documents via file(), content-hash versioning, and the two-account apply flow |
 | [workflows/approval-gate](workflows/approval-gate/) | A build workflow that pauses for human approval before the image is created - WaitForAction, an SNS approval request, and the RESUME/STOP response flow |
+| [workflows/step-functions-integration](workflows/step-functions-integration/) | A Step Functions state machine validates the output AMI from outside - no test instance - alongside an on-instance test workflow in the same parallel group |
 
 ### CloudFormation - Linux AMIs
 

--- a/workflows/approval-gate/README.md
+++ b/workflows/approval-gate/README.md
@@ -18,7 +18,7 @@ aws imagebuilder send-workflow-step-action \
 
 The console offers the same controls: the Images page's **Waiting for action** tab lists every paused step, with resume and stop actions.
 
-`RESUME` continues to `CreateImage`; `STOP` ends the workflow and the build fails. If nobody responds, the step times out - 3 days by default, up to 7 via `timeoutSeconds` on the step - and the build fails.
+`RESUME` continues the workflow - the instance is sanitized, then the image is created; `STOP` ends the workflow and the build fails. If nobody responds, the step times out - 3 days by default, up to 7 via `timeoutSeconds` on the step - and the build fails.
 
 Details worth knowing:
 

--- a/workflows/approval-gate/approval-gate.yml
+++ b/workflows/approval-gate/approval-gate.yml
@@ -232,6 +232,14 @@ Resources:
               snsTopicArn.$: "$.parameters.approvalTopicArn"
               payload: 'Inspect the build instance for this step execution, then approve (RESUME) or reject (STOP) the image.'
 
+          # Sanitize runs after the approval, so the approver can still
+          # reach the instance over SSM while the build is paused.
+          - name: SanitizeBuildInstance
+            action: SanitizeInstance
+            onFailure: Abort
+            inputs:
+              instanceId.$: "$.stepOutputs.LaunchBuildInstance.instanceId"
+
           - name: CreateOutputImage
             action: CreateImage
             onFailure: Abort

--- a/workflows/step-functions-integration/README.md
+++ b/workflows/step-functions-integration/README.md
@@ -1,0 +1,65 @@
+# Validate the output AMI with Step Functions
+
+Test components check an image from the inside - they run on an instance launched from it. This sample adds the other half: a test workflow whose single `ExecuteStateMachine` step hands the output AMI to a Step Functions state machine, which validates registration properties no on-instance test can see - and a failed check fails the image before anything downstream consumes it. No test instance launches for that check. A conventional on-instance test workflow runs alongside it in the same parallel group. Everything lives in one CloudFormation template: [step-functions-integration.yml](step-functions-integration.yml).
+
+## How the validation works
+
+1. The build workflow is a standard build with one addition: it exports the output image ID (`outputs: ImageId`). Workflows pass data across stages through outputs - the test workflow reads it as `$.workflowOutputs.ImageId`.
+2. The `sfn-integration-validate-ami` test workflow is a single `ExecuteStateMachine` step. Its execution input is a JSON string with runtime values embedded through `{{ }}` dynamic variables - the AMI ID from the build workflow's output, and the root-volume limit from a workflow parameter. Inputs that carry dynamic variables take the `.$` suffix on the key - the documented chaining rule.
+3. The state machine invokes a Lambda that describes the AMI and checks it against release criteria: ENA support enabled, not publicly launchable, root volume within the size limit. Any finding fails the execution, the step, and the workflow - and a failed test workflow fails the image.
+4. `ExecuteStateMachine` waits for the execution to finish (6 hours by default, up to 24 via `timeoutSeconds`). The execution role carries `states:StartExecution` on the state machine and `states:DescribeExecution` on its executions - that pair is what the step needs.
+
+The Lambda is the swap point. The shipped checks run anywhere with zero setup; this is where you'd plug in your own release bar - launch a scan, wait on findings, gate on severity.
+
+## How the parallel tests work
+
+- The pipeline names the build workflow plus two test workflows in its `Workflows` property. Setting that property replaces the defaults: exactly what's named runs.
+- Both test workflows carry `ParallelGroup: post-build`, so they run at the same time: the OS check launches its own instance from the output AMI (in the test stage, `LaunchInstance` defaults to the image the build produced) while the AMI validation runs with no instance at all.
+
+## Cost
+
+- Each build bills a t3.medium build instance, then one t3.medium test instance for the OS check - the Step Functions validation launches none.
+- Each output AMI's snapshot bills until you deregister the AMI and delete the snapshot.
+- The state machine and Lambda bill per execution at standard rates - negligible next to the instance time.
+
+## Prerequisites
+
+- A default VPC in the deployment region (or set `SubnetId`/`SecurityGroupIds` on the infrastructure configuration).
+- AWS CLI with permissions to deploy CloudFormation stacks with IAM resources.
+
+## Deploy
+
+```shell
+aws cloudformation deploy \
+  --template-file step-functions-integration.yml \
+  --stack-name sfn-integration \
+  --capabilities CAPABILITY_IAM
+```
+
+## Testing
+
+1. Start a build: `aws imagebuilder start-image-pipeline-execution --image-pipeline-arn <ImagePipelineArn output>`.
+2. After the build stage, both test workflows run at once: `aws imagebuilder list-workflow-executions --image-build-version-arn <build arn>` shows all three workflows, and the two test entries start together.
+3. Watch the validation execute: `aws stepfunctions list-executions --state-machine-arn <ValidationStateMachineArn output>`. Its input carries the AMI ID resolved from the build workflow's output - read it with `aws stepfunctions describe-execution --execution-arn <arn> --query input`.
+4. The build reaches `AVAILABLE` in roughly 10 to 25 minutes end to end.
+
+### Watch the gate fail a build
+
+Lower the root-volume limit below the image's actual size and run again:
+
+```shell
+aws cloudformation deploy \
+  --template-file step-functions-integration.yml \
+  --stack-name sfn-integration \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides MaxRootVolumeGib=4
+```
+
+Start a build: the validation fails, its workflow ends in `ROLLBACK_COMPLETED` (the terminal status of a failed test workflow), the in-flight OS check is cancelled, and the image fails. The failed build still registered an AMI - the gate runs after `CreateImage` - so cleanup covers it like any other build. The findings read from the failed execution: `aws stepfunctions describe-execution --execution-arn <arn> --query cause`. Restore the gate with `--parameter-overrides MaxRootVolumeGib=16` - note that redeploying without the override keeps the previous value.
+
+## Cleanup
+
+1. Delete the image build versions (`aws imagebuilder delete-image --image-build-version-arn <arn>` per build).
+2. Deregister the `sfn-integration-*` AMIs and delete their snapshots.
+3. Delete the stack: `aws cloudformation delete-stack --stack-name sfn-integration`.
+4. If a build ran recently, the log groups can reappear after deletion while late log deliveries land - delete them again before redeploying the same stack name, or the deploy fails on the name conflict.

--- a/workflows/step-functions-integration/step-functions-integration.yml
+++ b/workflows/step-functions-integration/step-functions-integration.yml
@@ -1,0 +1,455 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >
+  EC2 Image Builder with Step Functions: a test workflow hands the output
+  AMI to a state machine that validates its registration properties from
+  outside the instance, and a failed check fails the image. A conventional
+  on-instance test workflow runs in the same parallel group.
+
+Parameters:
+  MaxRootVolumeGib:
+    Type: String
+    Default: '16'
+    AllowedPattern: ^\d+$
+    Description: >-
+      Largest root volume the AMI validation accepts, in GiB. Redeploy with
+      a value below the image's root volume size to watch the gate fail a
+      build.
+
+Resources:
+  # ---------------------------------------------------------------------
+  # The execution role. Required whenever custom workflows are attached.
+  # The managed policy covers the workflow actions; the inline statement
+  # covers starting and tracking this stack's state machine.
+  # ---------------------------------------------------------------------
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - imagebuilder.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2ImageBuilderExecutionPolicy'
+      Policies:
+        - PolicyName: RunValidationStateMachine
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - states:StartExecution
+                Resource:
+                  - !Ref ValidationStateMachine
+              # ExecuteStateMachine waits for the result, which takes
+              # DescribeExecution on the executions the step starts.
+              - Effect: Allow
+                Action:
+                  - states:DescribeExecution
+                Resource:
+                  - !Sub 'arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:execution:${ValidationStateMachine.Name}:*'
+
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+        - !Ref InstanceRole
+
+  # ---------------------------------------------------------------------
+  # The AMI validation: a Lambda that checks the output AMI's registration
+  # properties - things no on-instance test can see - wrapped in a state
+  # machine that passes or fails on the result. Swap the Lambda's checks
+  # for your own release criteria; this is also where a heavier gate would
+  # launch a scan and wait on its findings.
+  # ---------------------------------------------------------------------
+  ValidationFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      Policies:
+        - PolicyName: DescribeOutputAmi
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              # Describe calls can't be resource-scoped.
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeImages
+                Resource: '*'
+
+  ValidationFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /sfn-integration/validation-lambda
+      RetentionInDays: 30
+
+  ValidationFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Validates the output AMI's registration properties.
+      Runtime: python3.13
+      Handler: index.handler
+      Timeout: 30
+      Role: !GetAtt ValidationFunctionRole.Arn
+      LoggingConfig:
+        LogGroup: !Ref ValidationFunctionLogGroup
+      Code:
+        ZipFile: |
+          import boto3
+
+          ec2 = boto3.client("ec2")
+
+          def handler(event, context):
+              image = ec2.describe_images(ImageIds=[event["imageId"]])["Images"][0]
+              max_root_gib = int(event["maxRootVolumeGib"])
+              findings = []
+              if not image.get("EnaSupport"):
+                  findings.append("ENA support is not enabled")
+              if image.get("Public"):
+                  findings.append("AMI is publicly launchable")
+              root = next((m["Ebs"] for m in image["BlockDeviceMappings"]
+                           if m.get("DeviceName") == image.get("RootDeviceName")
+                           and "Ebs" in m), {})
+              if root.get("VolumeSize", 0) > max_root_gib:
+                  findings.append(
+                      f"root volume {root['VolumeSize']} GiB exceeds {max_root_gib} GiB")
+              summary = "; ".join(findings) or "all checks passed"
+              print(f"{event['imageId']}: {summary}")
+              return {
+                  "compliant": not findings,
+                  "imageId": event["imageId"],
+                  "findingsSummary": summary,
+              }
+
+  StateMachineRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - states.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: InvokeValidationFunction
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !GetAtt ValidationFunction.Arn
+
+  ValidationStateMachine:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: sfn-integration-release-checks
+      RoleArn: !GetAtt StateMachineRole.Arn
+      Definition:
+        StartAt: CheckImage
+        States:
+          CheckImage:
+            Type: Task
+            Resource: !GetAtt ValidationFunction.Arn
+            Next: IsCompliant
+          IsCompliant:
+            Type: Choice
+            Choices:
+              - Variable: $.compliant
+                BooleanEquals: true
+                Next: Compliant
+            Default: NotCompliant
+          Compliant:
+            Type: Succeed
+          NotCompliant:
+            Type: Fail
+            Error: AmiValidationFailed
+            # CausePath surfaces the concrete findings on the failed
+            # execution, where the failed workflow step points.
+            CausePath: $.findingsSummary
+
+  # ---------------------------------------------------------------------
+  # A minimal component so the recipe has something to build.
+  # ---------------------------------------------------------------------
+  BuildInfoComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: sfn-integration-build-info
+      # Creating a component needs a concrete version (x wildcards are for
+      # references). The service increments the build number behind the same
+      # version when the document changes, and the recipe's LatestVersion
+      # reference picks that up.
+      Version: 1.0.0
+      Platform: Linux
+      Data: |
+        name: sfn-integration-build-info
+        description: Writes build metadata into the image.
+        schemaVersion: 1.0
+        phases:
+          - name: build
+            steps:
+              - name: WriteBuildInfo
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - mkdir -p /opt/sfn-integration
+                    - date -u '+Built on %Y-%m-%dT%H:%M:%SZ' > /opt/sfn-integration/build-info.txt
+
+  ImageRecipe:
+    Type: AWS::ImageBuilder::ImageRecipe
+    Properties:
+      Name: sfn-integration
+      # x auto-increments the build version, so updates that replace the
+      # recipe never collide with an existing name + version pair.
+      Version: 1.0.x
+      # x.x.x resolves to the latest release of the managed parent image at
+      # build time.
+      ParentImage: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/amazon-linux-2023-x86/x.x.x'
+      Components:
+        - ComponentArn: !GetAtt BuildInfoComponent.LatestVersion.Arn
+
+  BuildLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/sfn-integration
+      RetentionInDays: 30
+
+  PipelineLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/pipeline/sfn-integration
+      RetentionInDays: 30
+
+  InfrastructureConfiguration:
+    Type: AWS::ImageBuilder::InfrastructureConfiguration
+    Properties:
+      Name: sfn-integration
+      InstanceProfileName: !Ref InstanceProfile
+      InstanceTypes:
+        - t3.medium
+      InstanceMetadataOptions:
+        HttpTokens: required
+      # Build instances launch in the account's default VPC. Without a
+      # default VPC, set SubnetId and SecurityGroupIds here.
+
+  # ---------------------------------------------------------------------
+  # The build workflow: a standard build that exports the output image ID.
+  # Workflows pass data across stages through outputs - the test workflow
+  # reads this one as $.workflowOutputs.ImageId.
+  # ---------------------------------------------------------------------
+  BuildWorkflow:
+    Type: AWS::ImageBuilder::Workflow
+    Properties:
+      Name: sfn-integration-build
+      # Workflows version like components: concrete at creation, x wildcards
+      # when referencing.
+      Version: 1.0.0
+      Type: BUILD
+      Data: |
+        name: sfn-integration-build
+        description: Standard build that exports the output image ID for the test stage.
+        schemaVersion: 1.0
+
+        steps:
+          - name: LaunchBuildInstance
+            action: LaunchInstance
+            onFailure: Abort
+            inputs:
+              waitFor: ssmAgent
+
+          - name: ApplyBuildComponents
+            action: ExecuteComponents
+            onFailure: Abort
+            inputs:
+              instanceId.$: "$.stepOutputs.LaunchBuildInstance.instanceId"
+
+          - name: SanitizeBuildInstance
+            action: SanitizeInstance
+            onFailure: Abort
+            inputs:
+              instanceId.$: "$.stepOutputs.LaunchBuildInstance.instanceId"
+
+          - name: CreateOutputImage
+            action: CreateImage
+            onFailure: Abort
+            inputs:
+              instanceId.$: "$.stepOutputs.LaunchBuildInstance.instanceId"
+
+          - name: TerminateBuildInstance
+            action: TerminateInstance
+            onFailure: Continue
+            inputs:
+              instanceId.$: "$.stepOutputs.LaunchBuildInstance.instanceId"
+
+        outputs:
+          - name: ImageId
+            value: "$.stepOutputs.CreateOutputImage.imageId"
+
+  # ---------------------------------------------------------------------
+  # Two test workflows that run in the same parallel group. The OS check
+  # launches an instance from the output AMI and tests the image from the
+  # inside; the AMI validation runs no instance at all - its single step
+  # hands the AMI to the state machine, which checks it from the outside.
+  # ---------------------------------------------------------------------
+  OsCheckWorkflow:
+    Type: AWS::ImageBuilder::Workflow
+    Properties:
+      Name: sfn-integration-os-check
+      Version: 1.0.0
+      Type: TEST
+      Data: |
+        name: sfn-integration-os-check
+        description: Verifies the built image boots and reports the expected OS.
+        schemaVersion: 1.0
+
+        steps:
+          # In the test stage, LaunchInstance defaults to the image the
+          # build produced.
+          - name: LaunchTestInstance
+            action: LaunchInstance
+            onFailure: Abort
+            inputs:
+              waitFor: ssmAgent
+
+          - name: CheckOsRelease
+            action: RunCommand
+            onFailure: Abort
+            inputs:
+              instanceId.$: "$.stepOutputs.LaunchTestInstance.instanceId"
+              documentName: AWS-RunShellScript
+              parameters:
+                # A single chained command: the document's exit status is the
+                # last command's, so separate list entries wouldn't each gate.
+                commands:
+                  - grep -q 'Amazon Linux' /etc/os-release && test -s /opt/sfn-integration/build-info.txt
+
+          - name: TerminateTestInstance
+            action: TerminateInstance
+            onFailure: Continue
+            inputs:
+              instanceId.$: "$.stepOutputs.LaunchTestInstance.instanceId"
+
+  ValidateAmiWorkflow:
+    Type: AWS::ImageBuilder::Workflow
+    Properties:
+      Name: sfn-integration-validate-ami
+      Version: 1.0.0
+      Type: TEST
+      Data: |
+        name: sfn-integration-validate-ami
+        description: Hands the output AMI to a Step Functions state machine for validation.
+        schemaVersion: 1.0
+
+        parameters:
+          - name: stateMachineArn
+            type: string
+            description: The validation state machine to run against the output AMI.
+          - name: maxRootVolumeGib
+            type: string
+            description: Largest root volume the validation accepts, in GiB.
+
+        steps:
+          # The execution input is a JSON string; values wrapped in double
+          # curly braces resolve at runtime, and the .$ suffix marks an input
+          # that carries dynamic variables (the documented chaining rule).
+          - name: ValidateOutputAmi
+            action: ExecuteStateMachine
+            onFailure: Abort
+            inputs:
+              stateMachineArn.$: "$.parameters.stateMachineArn"
+              input.$: |
+                {
+                  "imageId": "{{ $.workflowOutputs.ImageId }}",
+                  "maxRootVolumeGib": "{{ $.parameters.maxRootVolumeGib }}"
+                }
+
+  DistributionConfiguration:
+    Type: AWS::ImageBuilder::DistributionConfiguration
+    Properties:
+      Name: sfn-integration
+      Distributions:
+        - Region: !Ref AWS::Region
+          AmiDistributionConfiguration:
+            Name: 'sfn-integration-{{ imagebuilder:buildDate }}'
+
+  ImagePipeline:
+    Type: AWS::ImageBuilder::ImagePipeline
+    Properties:
+      Name: sfn-integration
+      Description: Builds, then validates the output AMI in parallel - on the instance and through Step Functions.
+      ImageRecipeArn: !Ref ImageRecipe
+      InfrastructureConfigurationArn: !Ref InfrastructureConfiguration
+      DistributionConfigurationArn: !Ref DistributionConfiguration
+      ExecutionRole: !GetAtt ExecutionRole.Arn
+      LoggingConfiguration:
+        ImageLogGroupName: !Ref BuildLogGroup
+        PipelineLogGroupName: !Ref PipelineLogGroup
+      # Setting Workflows replaces the defaults: exactly these three run.
+      # The two test workflows share a parallel group, so they run at the
+      # same time.
+      Workflows:
+        - WorkflowArn: !GetAtt BuildWorkflow.Arn
+        - WorkflowArn: !GetAtt OsCheckWorkflow.Arn
+          ParallelGroup: post-build
+        - WorkflowArn: !GetAtt ValidateAmiWorkflow.Arn
+          ParallelGroup: post-build
+          Parameters:
+            - Name: stateMachineArn
+              Value:
+                - !Ref ValidationStateMachine
+            - Name: maxRootVolumeGib
+              Value:
+                - !Ref MaxRootVolumeGib
+
+Outputs:
+  ImagePipelineArn:
+    Description: >-
+      ARN of the image pipeline. Start a build with 'aws imagebuilder
+      start-image-pipeline-execution --image-pipeline-arn <this value>'.
+    Value: !Ref ImagePipeline
+  ValidationStateMachineArn:
+    Description: The state machine the test stage runs against the output AMI.
+    Value: !Ref ValidationStateMachine


### PR DESCRIPTION
# Description

Includes a sample of using custom workflows - 2 parallel test workflows, 1 that runs a SFN state machine, and 1 that does a custom RunCommand step validation. This illustrates the customization capabilities of custom image workflows.

Also adds a missing sanitize step to a previous example with a custom image workflow.

## Checklist

- [X] I deployed this sample in my own account and it created AND deleted cleanly (no leftover AMIs, snapshots, or non-empty buckets beyond what the README documents)
- [X] The README covers prerequisites, deployment, and cleanup for what I changed
- [X] No account IDs, ARNs from real accounts, or credentials anywhere in the change - including test data
- [X] If this adds a sample, it's listed in the root README index

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
