### PR TITLE
Validate Windows components on the Linux runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,10 +40,9 @@ jobs:
           pip install cfn-lint==1.55.1
           xargs -0 -r cfn-lint --non-zero-exit-code error < changed.txt
 
-  # awstoe validates a document against the action modules of the OS it runs
-  # on, so Windows components (ExecutePowerShell and friends) fail on a Linux
-  # runner. Components/Windows/ documents get the Windows binary on a Windows
-  # runner; everything else runs on Linux.
+  # awstoe validates a document against one OS's action modules, and the
+  # --os-platforms flag picks which - so Windows components (ExecutePowerShell
+  # and friends) validate on the Linux runner alongside everything else.
   awstoe-validate:
     name: awstoe validate changed components
     runs-on: ubuntu-latest
@@ -61,7 +60,6 @@ jobs:
           # Ansible playbooks, which awstoe rejects
           git diff -z --name-only --diff-filter=ACMR "origin/${BASE_REF}"...HEAD \
             | grep -zE '\.(yml|yaml)$' \
-            | grep -zv '^Components/Windows/' \
             | sed -z 's|^|./|' \
             | xargs -0 -r grep -lZ '^schemaVersion:' > changed.txt || true
           echo "count=$(tr -cd '\0' < changed.txt | wc -c)" >> "$GITHUB_OUTPUT"
@@ -87,52 +85,17 @@ jobs:
           chmod +x "$tool/awstoe"
           failed=0
           while IFS= read -rd '' doc; do
-            echo "::group::$doc"
-            "$tool/awstoe" validate --documents "$doc" || failed=1
+            # Components/Windows/ documents carry Windows-only actions, so
+            # they validate against the Windows action modules.
+            case "$doc" in
+              ./Components/Windows/*) platform=windows ;;
+              *) platform=linux ;;
+            esac
+            echo "::group::$doc ($platform)"
+            "$tool/awstoe" validate --documents "$doc" --os-platforms "$platform" || failed=1
             echo "::endgroup::"
           done < changed.txt
           exit "$failed"
-
-  awstoe-validate-windows:
-    name: awstoe validate changed Windows components
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          fetch-depth: 0
-      - name: Find changed Windows component documents
-        id: changed
-        shell: bash
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          git diff -z --name-only --diff-filter=ACMR "origin/${BASE_REF}"...HEAD \
-            | grep -zE '\.(yml|yaml)$' \
-            | grep -z '^Components/Windows/' \
-            | sed -z 's|^|./|' \
-            | xargs -0 -r grep -lZ '^schemaVersion:' > changed.txt || true
-          echo "count=$(tr -cd '\0' < changed.txt | wc -c)" >> "$GITHUB_OUTPUT"
-          tr '\0' '\n' < changed.txt
-      - name: Validate with awstoe
-        if: steps.changed.outputs.count != '0'
-        shell: pwsh
-        run: |
-          # AWS signs the Windows binary with Authenticode rather than
-          # publishing a detached signature, so verification differs from the
-          # Linux job's GPG check.
-          Invoke-WebRequest -Uri https://awstoe-us-east-1.s3.us-east-1.amazonaws.com/latest/windows/amd64/awstoe.exe -OutFile awstoe.exe
-          $sig = Get-AuthenticodeSignature .\awstoe.exe
-          if ($sig.Status -ne 'Valid' -or $sig.SignerCertificate.Subject -notlike '*Amazon*') {
-            throw "awstoe.exe signature check failed: $($sig.Status)"
-          }
-          $failed = 0
-          foreach ($doc in (Get-Content -Raw changed.txt) -split "`0" | Where-Object { $_ }) {
-            Write-Output "::group::$doc"
-            .\awstoe.exe validate --documents "$doc"
-            if ($LASTEXITCODE -ne 0) { $failed = 1 }
-            Write-Output "::endgroup::"
-          }
-          exit $failed
 
   params-parse:
     name: JSON parameter files parse

--- a/awstoe/README.md
+++ b/awstoe/README.md
@@ -9,7 +9,7 @@ The service checks a component's YAML when you create it - but whether the compo
 ./awstoe-local.sh run cookbook/conditional-install.yml --phases build
 ```
 
-`validate` runs natively and catches unknown actions, misspelled fields, missing phases, and undeclared `{{ }}` references - most of what `CreateComponent` checks, here without a deploy, credentials, or a network, so it fits a pre-commit hook or CI. `run` is what needs no service equivalent: it executes the document inside an Amazon Linux 2023 container (built from the [Dockerfile](Dockerfile)) and drops the same logs a real build produces under `./awstoe-logs/` - on failure the script prints the console tail. `--parameters name=value,name2=value2` passes component parameters.
+`validate` runs natively and catches unknown actions, misspelled fields, missing phases, and undeclared `{{ }}` references - most of what `CreateComponent` checks, here without a deploy, credentials, or a network, so it fits a pre-commit hook or CI. It checks against the host's action modules by default; `--os-platforms windows` (or `linux`, `darwin`) validates a document for another platform, so Windows components check out from a Linux machine. `run` is what needs no service equivalent: it executes the document inside an Amazon Linux 2023 container (built from the [Dockerfile](Dockerfile)) and drops the same logs a real build produces under `./awstoe-logs/` - on failure the script prints the console tail. `--parameters name=value,name2=value2` passes component parameters.
 
 Components run with no sandbox, and a rebooting step writes to your crontab and calls `shutdown` - inside the container neither touches your machine, the filesystem the component mutates is thrown away, and the environment matches your pipeline's Amazon Linux build instances. `run --host` skips the container if you know exactly what a document does; it refuses to run as root, and local runs block the `Reboot` action module in both modes, though a bare `exit 194` still gets through on the host. The container isn't a sandbox for components you don't trust.
 
@@ -17,7 +17,7 @@ The script verifies the binary's GPG signature against the fingerprint published
 
 ### What local runs can't do
 
-- Windows documents don't validate on Linux (or the reverse) - the action registry is host-specific. `ExecutePowerShell` on a Linux machine fails with `Unsupported action`.
+- This script's `run` executes Linux documents only, because its container is Amazon Linux 2023. Windows documents still validate from Linux (`--os-platforms windows`); executing one takes `awstoe.exe` on a Windows machine.
 - Required parameters you don't pass render as empty strings locally; the service rejects them at build time.
 - Actions that call AWS (`S3Download`, the secrets pattern, an S3-hosted document) need real credentials - export them as environment variables and they pass into the container. Everything else runs offline - set `AWS_EC2_METADATA_DISABLED=true` off-EC2 to skip a metadata-probe delay.
 - A local run proves your document's logic, not the image: base-image contents, the instance profile, and the post-build cleanup only exist in a real build.

--- a/awstoe/awstoe-local.sh
+++ b/awstoe/awstoe-local.sh
@@ -5,7 +5,7 @@
 # Local AWSTOE runner: validate and execute EC2 Image Builder component
 # documents in seconds, without a pipeline build.
 #
-#   ./awstoe-local.sh validate <doc.yml> [more docs...]
+#   ./awstoe-local.sh validate [--os-platforms windows|linux|darwin] <doc.yml> [more docs...]
 #   ./awstoe-local.sh run <doc.yml> [--phases build,validate] [--parameters n=v,...]
 #
 # validate runs natively. run executes inside an Amazon Linux 2023 container:
@@ -82,10 +82,19 @@ run_in_docker() {
 }
 
 cmd_validate() {
+  local platforms=""
+  if [ "${1:-}" = "--os-platforms" ]; then
+    [ "$#" -ge 2 ] || die "--os-platforms needs a value (windows, linux, or darwin)"
+    platforms="$2"; shift 2
+  fi
   [ "$#" -ge 1 ] || die "validate needs at least one document (awstoe exits 0 on an empty list)"
   local bin; bin="$(fetch_binary)"
   local docs; docs="$(IFS=,; echo "$*")"
-  "$bin" validate --documents "$docs"
+  if [ -n "$platforms" ]; then
+    "$bin" validate --documents "$docs" --os-platforms "$platforms"
+  else
+    "$bin" validate --documents "$docs"
+  fi
 }
 
 cmd_run() {
@@ -121,7 +130,7 @@ cmd_run() {
   exit "$rc"
 }
 
-[ "$#" -ge 1 ] || die "usage: $0 validate <docs...> | run [--host] <doc> [args]"
+[ "$#" -ge 1 ] || die "usage: $0 validate [--os-platforms windows|linux|darwin] <docs...> | run [--host] <doc> [args]"
 sub="$1"; shift
 case "$sub" in
   validate) cmd_validate "$@" ;;


### PR DESCRIPTION
# Description

AWSTOE now has a CLI command for the os platforms when running `validate` - so we can now remove out Windows runner and validate purely on Linux.

## Checklist

- [X] I deployed this sample in my own account and it created AND deleted cleanly (no leftover AMIs, snapshots, or non-empty buckets beyond what the README documents)
- [X] The README covers prerequisites, deployment, and cleanup for what I changed
- [X] No account IDs, ARNs from real accounts, or credentials anywhere in the change - including test data
- [X] If this adds a sample, it's listed in the root README index

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
