### PR TITLE
Add a Windows golden image sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ From there:
 | [awstoe](awstoe/) | Component patterns that are hard to get right the first time - reboot-and-resume, build-time secrets, cleanup overrides - plus a script that validates and runs component documents locally in seconds |
 | [debugging](debugging/) | A build that fails on purpose, and the walkthrough that diagnoses it - where each failure class leaves evidence, the workflow execution APIs, and a Session Manager shell on the kept build instance |
 | [containers](containers/) | Container base images on a weekly pipeline - the build-host-vs-base-image distinction, Dockerfile template variables, ECR tagging strategy, multi-region replication, and a Windows Server 2025 Core variant (CloudFormation, plus a CDK app for the Linux pipeline) |
+| [windows-golden-image](windows-golden-image/) | A monthly Windows Server 2025 golden image - reboot-safe patching through UpdateOS, what the service's sysprep already handles, which customization scopes survive into the AMI, verification on a fresh instance, and optional EC2 Fast Launch |
 
 ### CloudFormation - Linux AMIs
 

--- a/windows-golden-image/README.md
+++ b/windows-golden-image/README.md
@@ -1,0 +1,125 @@
+# A patched, verified Windows golden image
+
+This kit runs a monthly Windows Server 2025 pipeline that patches with the managed `update-windows` component, applies machine-scope baseline configuration, and then proves the result where it counts: a test phase on a fresh instance launched from the sysprepped AMI, asserting the baseline is present and zero software updates are pending. Optional EC2 Fast Launch pre-provisioning sits behind the `EnableFastLaunch` parameter.
+
+Everything lives in one CloudFormation template, [windows-golden-image.yml](windows-golden-image.yml). The kit stops at the verified AMI - for promoting each new AMI into a launch template, rolling a fleet onto it, and getting notified when a scheduled build fails, see the [golden AMI pipeline kit](../golden-ami-pipeline/).
+
+## What the service already does to your Windows build
+
+Before writing components, know what the default build workflow handles - a lot of published Windows advice duplicates or fights it:
+
+- **Sysprep runs automatically.** The last step before the snapshot runs Microsoft Sysprep through the `AWSEC2-RunSysprep` Systems Manager document, which drives the launch agent's own sysprep flow (`EC2Launch.exe sysprep` on EC2Launch v2). That flow resets the agent state, so user data runs on instances launched from your AMI - no re-arming component needed.
+- **The Administrator password is rotated.** The same `AWSEC2-RunSysprep` document sets a new random password on the built-in Administrator account (found by its RID, so renaming it doesn't opt out) and runs sysprep in that admin session - so it runs after your components, and a password set in one doesn't survive. Local account passwords belong in launch-time user data or Group Policy.
+- **The AMI is captured cold.** The instance is stopped before the snapshot, so nothing boots between generalization and capture.
+- **Nothing else is cleaned.** Unlike Linux builds, there's no sanitize script and no file cleanup beyond sysprep's own generalization - `C:\Windows\Temp` contents survive into the AMI, for example. What your components leave behind, the image keeps.
+
+## Where customizations survive
+
+Components run as `NT AUTHORITY\SYSTEM` - not as a user - and the sysprep flow's answer file enables `CopyProfile`, which copies the built-in Administrator profile over the Default profile (applied when an instance first boots from the AMI). That pair of facts decides what makes it into your image:
+
+| You write to | On instances launched from the AMI |
+|---|---|
+| Machine scope - `HKLM`, `C:\ProgramData`, `Program Files` | Present. This is where baseline configuration belongs |
+| The Administrator profile (`C:\Users\Administrator`) | Present for every new user profile created on the instance - `CopyProfile` makes it the Default profile template |
+| A local user created during the build | Present - the account and its `C:\Users\` profile survive; sysprep regenerates the machine SID and remaps the profile to the account's new SID. Deleting accounts mid-build is the risky direction - stale profile references can fail sysprep |
+| `$env:USERPROFILE` as components see it | That's the SYSTEM profile under `C:\Windows\system32\config` - it survives, but no user ever sees it |
+
+## Reboots
+
+Patching reboots Windows, sometimes more than once per update. The `UpdateOS` action (what the managed `update-windows` component runs) is the path the service recognizes: when Windows fires an unplanned second reboot mid-update, the build retries instead of failing. A component that reboots by exiting 3010 resumes at the same step (the [AWSTOE cookbook](../awstoe/) covers that pattern), but it doesn't get that second-reboot coverage - keep patching in `UpdateOS`, and use the `Reboot` action for deliberate restarts.
+
+## Cost
+
+**This pipeline has a schedule.** It builds the third Monday monthly, and only when the base image or a component has updated. Each run bills a c5.xlarge for the build and a second instance for the test phase, plus the AMI and snapshot it produces. Build time tracks base-image freshness: about 20 minutes from the current month's base, an hour or more from a stale one. With `EnableFastLaunch=true`, each enabled AMI additionally launches temporary instances and maintains pre-provisioned snapshots that bill until you disable Fast Launch on that AMI - and old AMIs stay enabled until you disable each one, so clean up as you rotate. The AMIs and their snapshots also accrete monthly until pruned - the [lifecycle kit](../lifecycle/) automates that.
+
+## Prerequisites
+
+- AWS CLI v2 with credentials for an account and region where you can create IAM roles.
+- A default VPC (the infrastructure configuration doesn't pin a subnet).
+- A region where the managed Windows Server 2025 base image is available - `aws imagebuilder list-images --owner Amazon` shows the catalog.
+
+## Deploy
+
+```shell
+aws cloudformation deploy \
+  --template-file windows-golden-image.yml \
+  --stack-name windows-golden-image \
+  --capabilities CAPABILITY_IAM
+```
+
+## Testing
+
+1. Start a build and watch it to `AVAILABLE`:
+
+   ```shell
+   PIPELINE_ARN=$(aws cloudformation describe-stacks --stack-name windows-golden-image \
+     --query "Stacks[0].Outputs[?OutputKey=='ImagePipelineArn'].OutputValue" --output text)
+   IMAGE_ARN=$(aws imagebuilder start-image-pipeline-execution \
+     --image-pipeline-arn "$PIPELINE_ARN" --query imageBuildVersionArn --output text)
+   aws imagebuilder get-image --image-build-version-arn "$IMAGE_ARN" \
+     --query 'image.state' --output json
+   ```
+
+   The build already verified itself - the test phase ran on a fresh instance from the output AMI and asserted the baseline plus zero pending software updates.
+
+2. Prove the launch contract. Launch an instance from the output AMI with user data and confirm it ran:
+
+   ```shell
+   AMI=$(aws imagebuilder get-image --image-build-version-arn "$IMAGE_ARN" \
+     --query 'image.outputResources.amis[0].image' --output text)
+   cat > userdata.txt << 'EOF'
+   <powershell>
+   Set-Content -Path 'C:\ProgramData\golden-image\userdata-ran.txt' -Value "ran at $(Get-Date -Format o)"
+   </powershell>
+   EOF
+   PROFILE=$(aws cloudformation describe-stacks --stack-name windows-golden-image \
+     --query "Stacks[0].Outputs[?OutputKey=='InstanceProfileName'].OutputValue" --output text)
+   aws ec2 run-instances --image-id "$AMI" --instance-type t3.medium \
+     --iam-instance-profile "Name=$PROFILE" \
+     --metadata-options HttpTokens=required --user-data file://userdata.txt \
+     --query 'Instances[0].InstanceId' --output text
+   ```
+
+   Once the instance is up (Windows first boot takes a few minutes), check `C:\ProgramData\golden-image\userdata-ran.txt` over Session Manager. Terminate the instance when done.
+
+3. Fast Launch. Redeploy with Fast Launch enabled, then rerun the pipeline (step 1):
+
+   ```shell
+   aws cloudformation deploy \
+     --template-file windows-golden-image.yml \
+     --stack-name windows-golden-image \
+     --capabilities CAPABILITY_IAM \
+     --parameter-overrides EnableFastLaunch=true
+   ```
+
+   Once the new build is `AVAILABLE`, capture its AMI as in step 2 and watch the enablement - it takes several minutes after the build:
+
+   ```shell
+   aws ec2 describe-fast-launch-images --image-ids "$AMI" \
+     --query 'FastLaunchImages[0].State' --output text
+   ```
+
+   `enabling` then `enabled`. Disable it before deregistering the AMI: `aws ec2 disable-fast-launch --image-id "$AMI"`.
+
+## Common errors
+
+For general build triage - which failure leaves its evidence where - start with the [debugging kit](../debugging/). The rows below are the Windows-specific ones:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| The build runs far longer than usual | A stale base image accumulating a large cumulative update | Keep the recipe on the managed base's `x.x.x` (this template does) - a current base means a near-empty update pass |
+| `RunSysPrepScript` hangs, then the build fails with an SSM `Undeliverable` or timeout | Sysprep is blocked - an Appx package installed for a user but not provisioned for all users, or hardening that broke the SSM agent (DNS, removed COM ports) | Rerun with `TerminateInstanceOnFailure: false` on the infrastructure configuration to keep the failed instance, then check `C:\Windows\System32\Sysprep\Panther\setupact.log` on it; remove per-user packages with `-AllUsers` scope during the build |
+| `Can't enable EC2 Fast Launch. The IAM credentials that you are using do not have sufficient permissions.` | The pipeline runs as the service-linked role, which can't enable Fast Launch | Set an execution role on the pipeline carrying `EC2ImageBuilderExecutionPolicy` and `EC2FastLaunchFullAccess` (this template's `EnableFastLaunch` parameter wires it) |
+
+## Cleanup
+
+1. If you enabled Fast Launch, disable it on every AMI this pipeline produced (`aws ec2 describe-fast-launch-images`, then `aws ec2 disable-fast-launch --image-id <id>` for each) - disabling is what deletes an AMI's pre-provisioned snapshots, so do it before deregistering.
+2. Delete the image build versions: `aws imagebuilder list-image-build-versions --image-version-arn <arn>` (from `aws imagebuilder list-images --owner Self`) enumerates them, and `aws imagebuilder delete-image --image-build-version-arn <arn>` deletes each.
+3. Deregister the AMIs and delete their snapshots (`aws ec2 describe-images --owners self --filters Name=name,Values='windows-golden-image-*'`).
+4. Empty the log bucket, including all object versions and delete markers (the bucket is versioned - the S3 console's Empty button handles both), then delete the stack:
+
+   ```shell
+   aws cloudformation delete-stack --stack-name windows-golden-image
+   ```
+
+5. If a build ran recently, the log groups can reappear after deletion while late log deliveries land - delete them again before redeploying the same stack name, or the deploy fails on the name conflict.

--- a/windows-golden-image/windows-golden-image.yml
+++ b/windows-golden-image/windows-golden-image.yml
@@ -1,0 +1,327 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >
+  EC2 Image Builder Windows golden image: a monthly Windows Server 2025
+  pipeline that patches through the UpdateOS action, bakes machine-scope
+  baseline configuration, and verifies the result on a fresh instance
+  launched from the sysprepped AMI - with optional EC2 Fast Launch.
+
+Parameters:
+  EnableFastLaunch:
+    Type: String
+    Default: 'false'
+    AllowedValues: ['true', 'false']
+    Description: >-
+      Pre-provision the output AMI for EC2 Fast Launch. Launches temporary
+      instances and maintains snapshots that bill until you disable it - see
+      the README's Cost section.
+
+Conditions:
+  FastLaunchEnabled: !Equals [!Ref EnableFastLaunch, 'true']
+
+Resources:
+  # Receives the AWSTOE log bundle from each build; the CloudWatch groups
+  # below receive the streamed build output.
+  BuildLogBucket:
+    Type: AWS::S3::Bucket
+    # To keep the bucket when deleting the stack, set DeletionPolicy: Retain.
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          # Build logs are only useful for recent troubleshooting - expire
+          # them so the bucket doesn't accumulate cost
+          - Id: ExpireBuildLogs
+            Status: Enabled
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+
+  LogBucketTlsPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref BuildLogBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EnforceTls
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::${BuildLogBucket}'
+              - !Sub 'arn:${AWS::Partition}:s3:::${BuildLogBucket}/*'
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+          - Sid: EnforceTlsVersion
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::${BuildLogBucket}'
+              - !Sub 'arn:${AWS::Partition}:s3:::${BuildLogBucket}/*'
+            Condition:
+              NumericLessThan:
+                s3:TlsVersion: 1.2
+
+  # The pipeline runs as this role instead of the service-linked role - the
+  # recommended pattern, and required for Fast Launch, which needs more than
+  # the service-linked role carries.
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns: !If
+        - FastLaunchEnabled
+        # The execution policy's ARN has no service-role/ path prefix.
+        - - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2ImageBuilderExecutionPolicy'
+          - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2FastLaunchFullAccess'
+        - - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2ImageBuilderExecutionPolicy'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - imagebuilder.amazonaws.com
+
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+      Policies:
+        - PolicyName: ship-build-logs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3:PutObject
+                Resource: !Sub 'arn:${AWS::Partition}:s3:::${BuildLogBucket}/*'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+      Path: /executionServiceEC2Role/
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /executionServiceEC2Role/
+      Roles:
+        - !Ref InstanceRole
+
+  # Components run as NT AUTHORITY\SYSTEM, so baseline configuration
+  # belongs in machine scope. Changes use the native action modules;
+  # ExecutePowerShell is kept for assertions.
+  BaselineComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: windows-golden-image-baseline
+      # Components don't accept x wildcards at creation. Keep the version
+      # fixed - the service increments the build number behind it when the
+      # document changes.
+      Version: 1.0.0
+      Platform: Windows
+      Description: Applies machine-scope baseline configuration.
+      Data: |
+        name: windows-golden-image-baseline
+        description: Applies machine-scope baseline configuration.
+        schemaVersion: 1.0
+        phases:
+          - name: build
+            steps:
+              - name: CreateBaselineFolder
+                action: CreateFolder
+                inputs:
+                  - path: C:\ProgramData\golden-image
+              - name: WriteBaselineFile
+                action: CreateFile
+                inputs:
+                  - path: C:\ProgramData\golden-image\baseline.txt
+                    content: baseline applied
+                    overwrite: true
+              - name: SetBaselineRegistry
+                action: SetRegistry
+                inputs:
+                  - path: HKLM:\SOFTWARE\GoldenImage
+                    name: BaselineVersion
+                    value: '1'
+                    type: SZ
+          - name: validate
+            steps:
+              - name: VerifyBaseline
+                action: ExecutePowerShell
+                inputs:
+                  commands:
+                    - |
+                      if (-not (Test-Path 'C:\ProgramData\golden-image\baseline.txt')) { exit 1 }
+                      if (-not (Get-ItemProperty -Path 'HKLM:\SOFTWARE\GoldenImage' -Name BaselineVersion -ErrorAction SilentlyContinue)) { exit 1 }
+
+  # The test phase runs on a fresh instance launched from the sysprepped
+  # AMI - the same first boot your users get - so the patch state is
+  # asserted here.
+  VerifyComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: windows-golden-image-verify
+      Version: 1.0.0
+      Platform: Windows
+      Description: Verifies baseline and patch state on the output AMI.
+      Data: |
+        name: windows-golden-image-verify
+        description: Verifies baseline and patch state on the output AMI.
+        schemaVersion: 1.0
+        phases:
+          - name: test
+            steps:
+              - name: VerifyImage
+                action: ExecutePowerShell
+                timeoutSeconds: 1800
+                inputs:
+                  commands:
+                    - |
+                      # Fail closed: without this, a Windows Update COM failure
+                      # would leave $pending empty and the assertion would pass
+                      # vacuously.
+                      $ErrorActionPreference = 'Stop'
+                      if (-not (Test-Path 'C:\ProgramData\golden-image\baseline.txt')) { Write-Host 'baseline file missing'; exit 1 }
+                      if (-not (Get-ItemProperty -Path 'HKLM:\SOFTWARE\GoldenImage' -Name BaselineVersion -ErrorAction SilentlyContinue)) { Write-Host 'baseline registry key missing'; exit 1 }
+                      $searcher = (New-Object -ComObject Microsoft.Update.Session).CreateUpdateSearcher()
+                      $pending = $searcher.Search("IsInstalled=0 and IsHidden=0 and Type='Software'").Updates
+                      Write-Host "pending software updates: $($pending.Count)"
+                      foreach ($u in $pending) { Write-Host " - $($u.Title)" }
+                      if ($pending.Count -gt 0) { exit 1 }
+
+  ImageRecipe:
+    Type: AWS::ImageBuilder::ImageRecipe
+    Properties:
+      Name: windows-golden-image
+      # Changing the recipe replaces it; the x placeholder auto-increments
+      # the version on each replacement.
+      Version: 1.0.x
+      # The managed base image tracks the monthly Windows Server 2025
+      # releases; the pipeline's dependency-update start condition rebuilds
+      # when a new one publishes. Building from the current month's base
+      # keeps the update pass small.
+      ParentImage: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/windows-server-2025-english-full-base-x86/x.x.x'
+      Components:
+        # The managed patching component: one UpdateOS step with no timeout,
+        # and the reboot path the service recognizes and retries when Windows
+        # fires an unplanned second reboot mid-update. A hand-rolled reboot
+        # script gets none of that.
+        - ComponentArn: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:component/update-windows/x.x.x'
+        - ComponentArn: !GetAtt BaselineComponent.LatestVersion.Arn
+        - ComponentArn: !GetAtt VerifyComponent.LatestVersion.Arn
+      BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+            # Headroom for cumulative updates on top of the 30 GB base.
+            VolumeSize: 50
+            VolumeType: gp3
+            DeleteOnTermination: true
+
+  InfrastructureConfiguration:
+    Type: AWS::ImageBuilder::InfrastructureConfiguration
+    Properties:
+      Name: windows-golden-image
+      InstanceProfileName: !Ref InstanceProfile
+      # A c5.xlarge ran the full patch-and-verify build in about 21 minutes.
+      InstanceTypes:
+        - c5.xlarge
+      InstanceMetadataOptions:
+        HttpTokens: required
+      Logging:
+        S3Logs:
+          S3BucketName: !Ref BuildLogBucket
+          S3KeyPrefix: windows-golden-image
+
+  DistributionConfiguration:
+    Type: AWS::ImageBuilder::DistributionConfiguration
+    Properties:
+      Name: windows-golden-image
+      Distributions:
+        - Region: !Ref AWS::Region
+          AmiDistributionConfiguration:
+            Name: 'windows-golden-image-{{ imagebuilder:buildDate }}'
+          FastLaunchConfigurations: !If
+            - FastLaunchEnabled
+            # No launch template: EC2 Fast Launch creates its own resources,
+            # which is what the execution role's EC2FastLaunchFullAccess is
+            # for. EC2ImageBuilderExecutionPolicy alone only permits
+            # EnableFastLaunch on resources tagged CreatedBy: EC2 Image Builder.
+            - - Enabled: true
+                # The service requires at least 6.
+                MaxParallelLaunches: 6
+                SnapshotConfiguration:
+                  TargetResourceCount: 1
+            - !Ref AWS::NoValue
+
+  BuildLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/windows-golden-image
+      RetentionInDays: 7
+
+  PipelineLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/pipeline/windows-golden-image
+      RetentionInDays: 7
+
+  ImagePipeline:
+    Type: AWS::ImageBuilder::ImagePipeline
+    Properties:
+      Name: windows-golden-image
+      Description: Monthly patched and verified Windows Server 2025 golden image.
+      ImageRecipeArn: !Ref ImageRecipe
+      InfrastructureConfigurationArn: !Ref InfrastructureConfiguration
+      DistributionConfigurationArn: !Ref DistributionConfiguration
+      ExecutionRole: !GetAtt ExecutionRole.Arn
+      LoggingConfiguration:
+        ImageLogGroupName: !Ref BuildLogGroup
+        PipelineLogGroupName: !Ref PipelineLogGroup
+      # Updates land on the second Tuesday; the third-Monday build picks
+      # them up, and only when the base image or a component has updated.
+      Schedule:
+        ScheduleExpression: cron(0 9 ? * mon#3 *)
+        PipelineExecutionStartCondition: EXPRESSION_MATCH_AND_DEPENDENCY_UPDATES_AVAILABLE
+
+Outputs:
+  ImagePipelineArn:
+    Description: >-
+      ARN of the image pipeline. Start a build with 'aws imagebuilder
+      start-image-pipeline-execution --image-pipeline-arn <this value>'.
+    Value: !Ref ImagePipeline
+  BuildLogBucketName:
+    Description: Bucket receiving the AWSTOE log bundle from each build.
+    Value: !Ref BuildLogBucket
+  InstanceProfileName:
+    Description: >-
+      Instance profile for the README's launch-contract test - it carries the
+      Session Manager permissions.
+    Value: !Ref InstanceProfile


### PR DESCRIPTION
# Description

A monthly Windows Server 2025 pipeline that patches through the UpdateOS action - the reboot path the service recognizes and retries - applies machine-scope baseline configuration, and verifies the result on a fresh instance launched from the sysprepped AMI, asserting zero pending updates. The README documents what the service's sysprep flow already handles (agent state reset, Administrator password rotation, cold capture) and which customization scopes survive into the AMI, both verified with dedicated builds. EC2 Fast Launch pre-provisioning is available behind a parameter, using a custom execution role.

## Checklist

- [X] I deployed this sample in my own account and it created AND deleted cleanly (no leftover AMIs, snapshots, or non-empty buckets beyond what the README documents)
- [X] The README covers prerequisites, deployment, and cleanup for what I changed
- [X] No account IDs, ARNs from real accounts, or credentials anywhere in the change - including test data
- [X] If this adds a sample, it's listed in the root README index

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
