### PR TITLE
Add a macOS golden image sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ From there:
 | [debugging](debugging/) | A build that fails on purpose, and the walkthrough that diagnoses it - where each failure class leaves evidence, the workflow execution APIs, and a Session Manager shell on the kept build instance |
 | [containers](containers/) | Container base images on a weekly pipeline - the build-host-vs-base-image distinction, Dockerfile template variables, ECR tagging strategy, multi-region replication, and a Windows Server 2025 Core variant (CloudFormation, plus a CDK app for the Linux pipeline) |
 | [windows-golden-image](windows-golden-image/) | A monthly Windows Server 2025 golden image - reboot-safe patching through UpdateOS, what the service's sysprep already handles, which customization scopes survive into the AMI, verification on a fresh instance, and optional EC2 Fast Launch |
+| [macos-golden-image](macos-golden-image/) | A customized macOS AMI built on an EC2 Mac Dedicated Host - the placement wiring, optional in-stack host allocation, the 24-hour-minimum cost model, and how one pinned host serves both the build and test phases |
 
 ### CloudFormation - Linux AMIs
 

--- a/macos-golden-image/README.md
+++ b/macos-golden-image/README.md
@@ -1,0 +1,132 @@
+# Build a macOS golden image on an EC2 Mac Dedicated Host
+
+This kit runs an Image Builder pipeline that produces a customized macOS AMI: a managed macOS base image, a Homebrew baseline component, and an infrastructure configuration whose placement pins the build to an EC2 Mac Dedicated Host. A test phase asserts the baseline on a fresh instance from the output AMI - on the same host, once it finishes scrubbing.
+
+Everything lives in one CloudFormation template, [macos-golden-image.yml](macos-golden-image.yml).
+
+## The Dedicated Host comes first
+
+Mac instances only run on Dedicated Hosts, and Image Builder never allocates one for you - a build without an available host fails at launch. Host allocation is the first hurdle, because three different things can say no:
+
+| Error | What it means |
+|---|---|
+| `The requested configuration is currently not supported.` | Your account isn't entitled for that Mac instance family - request it through AWS Support |
+| `You do not have a host with a matching configuration and sufficient capacity.` | No allocated host is available to the build - allocate one first, or your host is in the wrong state or zone |
+| `InsufficientHostCapacity` on `allocate-hosts` | The family is entitled but the zone has no physical capacity right now - try another zone or retry later |
+
+A Service Quotas value above zero for `Running Dedicated mac Hosts` guarantees neither entitlement nor capacity - all three checks are separate. Find the zones that offer your instance type before allocating:
+
+```shell
+aws ec2 describe-instance-type-offerings --location-type availability-zone \
+  --filters Name=instance-type,Values=mac2-m2.metal --query 'InstanceTypeOfferings[].Location' --output text
+```
+
+The template allocates the host for you when `HostId` is left empty, or builds on a host you already own. To allocate one yourself:
+
+```shell
+aws ec2 allocate-hosts --instance-type mac2-m2.metal --availability-zone us-east-2a \
+  --quantity 1 --query 'HostIds[0]' --output text
+```
+
+If you bring your own host, its Availability Zone (`aws ec2 describe-hosts --host-ids h-example1111 --query 'Hosts[0].AvailabilityZone'`) has to match the `SubnetId` and `AvailabilityZone` you pass.
+
+**Know the cost model before allocating.** Mac Dedicated Hosts bill per second with a 24-hour minimum allocation period (an Apple licensing requirement) - a 30-minute build pays for 24 hours of host. Releasing also has stages: while an instance is (or was just) on the host it's `occupied` (`Client.InvalidHost.Occupied`), then the host scrubs (about 40 minutes measured on Intel, longer on Apple silicon), and inside the first 24 hours release is refused with `Client.HostMinAllocationPeriodUnexpired` naming the exact release time. If the stack allocated the host, deleting the stack inside those 24 hours fails on the host resource - retry the delete after the minimum has passed.
+
+## One host runs the whole pipeline
+
+A Dedicated Host runs one Mac instance at a time, and a pipeline with tests needs two instances in sequence: the build instance, then a test instance launched from the output AMI. One host still covers both, because the template pins the host in placement: Image Builder waits for the pinned host to finish scrubbing after the build instance terminates (about 40 minutes on Intel hosts, longer on Apple silicon), then launches the test instance on it. Set `TestAfterBuild=false` to skip the test phase and the scrub wait - the validate phase still asserts the baseline on the build instance either way.
+
+The wait comes from the pin. Placement with `tenancy: host` but no `hostId` auto-places instead, and an auto-placed test launch doesn't wait for a scrubbing host - it fails with `InsufficientHostCapacity`.
+
+## What the service already does on macOS
+
+- **Components run as root.** Homebrew belongs to `ec2-user` on AWS macOS AMIs, so brew commands run as that user: `sudo -iu ec2-user brew install jq`.
+- **The base image comes loaded.** AWS macOS AMIs ship with the SSM agent, AWS CLI, Homebrew, Xcode Command Line Tools, and EC2 macOS Init.
+- **Cleanup is handled.** The workflow runs a macOS sanitize step before the snapshot - build artifacts and instance state are cleaned without a custom component.
+- **The AMI is captured cold.** The instance is stopped before the snapshot.
+
+## Traps to know
+
+The [EC2 Mac instances guide](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-mac-instances.html) is the reference for host behavior; the ones that bite image builds:
+
+- **GUI permission prompts don't work headlessly.** macOS TCC permissions (screen recording, accessibility) require a human at a screen - Apple provides no headless approval path. Keep components to things that work in a shell.
+- **Don't enable FileVault** - the host fails to boot.
+- **Stay on the managed base.** Upgrading mid-build to a macOS version newer than the latest AWS-published AMI produces an AMI that won't boot on other hosts.
+- **Match architectures.** An arm64 base image needs an Apple silicon instance type; x86 bases need `mac1.metal`.
+
+## Cost
+
+**The Dedicated Host dominates.** Per-second host billing with a 24-hour minimum per allocation, whether the build takes 30 minutes or 12 hours - the release rules are under "The Dedicated Host comes first" above. Each build also produces an AMI and snapshot that bill until deregistered, and the pipeline deliberately has no schedule: a scheduled build would launch onto a host you may have already released. Back-to-back builds on one host serialize - the second waits out the first's scrubbing before it can launch.
+
+## Prerequisites
+
+- AWS CLI v2 with credentials for an account and region where you can create IAM roles.
+- Your account entitled for at least one Mac instance family, in a region with EC2 Mac capacity.
+- A subnet and security group in the host's Availability Zone (the security group needs no inbound rules - the SSM agent connects outbound).
+
+## Deploy
+
+Pick the zone, subnet, and security group, then deploy - leave `HostId` empty to let the stack allocate the host (24-hour minimum starts then):
+
+```shell
+aws cloudformation deploy \
+  --template-file macos-golden-image.yml \
+  --stack-name macos-golden-image \
+  --capabilities CAPABILITY_IAM \
+  --parameter-overrides \
+    AvailabilityZone=us-east-2a \
+    SubnetId=subnet-example111 \
+    SecurityGroupId=sg-example111
+```
+
+To build on a host you already allocated, add `HostId=h-example1111` and set `MacInstanceType`/`BaseImageName` to match it.
+
+## Testing
+
+1. Start a build and watch it to `AVAILABLE`. Mac instances boot slowly (the workflow retries its reachability checks for many minutes before components start), and with tests on the pipeline waits out the host's scrub between the build and test instances - about 70 minutes end to end on an Intel host. With `TestAfterBuild=false` it ends at the build, about 20 minutes:
+
+   ```shell
+   PIPELINE_ARN=$(aws cloudformation describe-stacks --stack-name macos-golden-image \
+     --query "Stacks[0].Outputs[?OutputKey=='ImagePipelineArn'].OutputValue" --output text)
+   IMAGE_ARN=$(aws imagebuilder start-image-pipeline-execution \
+     --image-pipeline-arn "$PIPELINE_ARN" --query imageBuildVersionArn --output text)
+   aws imagebuilder get-image --image-build-version-arn "$IMAGE_ARN" \
+     --query 'image.state' --output json
+   ```
+
+2. Confirm the baseline landed in the AMI. The test phase already asserted it on a fresh instance; to check it yourself, launch an instance from the output AMI onto an available host (Mac launches need the same host placement the build did) and inspect it over Session Manager:
+
+   ```shell
+   AMI=$(aws imagebuilder get-image --image-build-version-arn "$IMAGE_ARN" \
+     --query 'image.outputResources.amis[0].image' --output text)
+   aws ec2 run-instances --image-id "$AMI" --instance-type mac2-m2.metal \
+     --placement "Tenancy=host,HostId=h-example1111" \
+     --subnet-id subnet-example111 --metadata-options HttpTokens=required \
+     --query 'Instances[0].InstanceId' --output text
+   ```
+
+   Once it boots, `aws ssm start-session --target <instance-id>` and check `/usr/local/lib/golden-image/baseline.txt`. Terminate it when done - the host then scrubs.
+
+## Common errors
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `InsufficientHostCapacity ... in workflow step LaunchTestInstance` | The placement has no `hostId` - auto-placed launches don't wait for the host to finish scrubbing after the build | Pin the host in the placement (this template does) |
+| `InsufficientHostCapacity ... in workflow step LaunchBuildInstance` | No available host matches the zone and instance type | Check the host's state (`aws ec2 describe-hosts`) - a scrubbing host is `pending`, not `available` |
+| The build sits in `Building` or between phases for a long time | Mac instances boot slowly, and with tests on the pipeline waits out the host's scrub between build and test | Expected; budget it into pipeline timeouts |
+| `Client.InvalidHost.Occupied` on `release-hosts` | An instance is still on the host, or the host is scrubbing after one terminated | Wait for scrubbing to finish (the host shows `pending` until then) |
+| `Client.HostMinAllocationPeriodUnexpired` on `release-hosts` | The host hasn't been allocated for the full 24-hour minimum yet | The message states the exact time you can release it - wait until then |
+
+## Cleanup
+
+1. Delete the image build versions: `aws imagebuilder list-image-build-versions --image-version-arn <arn>` (from `aws imagebuilder list-images --owner Self`) enumerates them, and `aws imagebuilder delete-image --image-build-version-arn <arn>` deletes each.
+2. Deregister the AMIs and delete their snapshots (`aws ec2 describe-images --owners self --filters Name=name,Values='macos-golden-image-*'`).
+3. Empty the log bucket, including all object versions and delete markers (the bucket is versioned - the S3 console's Empty button handles both), then delete the stack:
+
+   ```shell
+   aws cloudformation delete-stack --stack-name macos-golden-image
+   ```
+
+   If the stack allocated the Dedicated Host and 24 hours haven't passed since allocation, the delete fails on the host resource (`Unable to release Dedicated Host ... must be allocated ... for at least 24 hour(s)`), leaving the stack `DELETE_FAILED`. Wait until the time the message names, then delete - that releases the host with the stack. Deleting again before then can drop the host from the stack while it keeps billing, so hold off rather than forcing it. A host that just ran an instance also scrubs before it can be released.
+4. Release any host you allocated yourself (the stack only releases the one it allocated): `aws ec2 release-hosts --host-ids h-example1111`. It keeps billing until you do, and the same 24-hour minimum and scrubbing rules apply.
+5. If a build ran recently, the log groups can reappear after deletion while late log deliveries land - delete them again before redeploying the same stack name, or the deploy fails on the name conflict.

--- a/macos-golden-image/macos-golden-image.yml
+++ b/macos-golden-image/macos-golden-image.yml
@@ -1,0 +1,335 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: >
+  EC2 Image Builder macOS golden image: a pipeline that builds a customized
+  macOS AMI on an EC2 Mac Dedicated Host - the host placement wiring, a
+  Homebrew baseline component, and a test phase served by the same pinned
+  host. The host can be allocated by the stack or brought in as a parameter.
+
+Parameters:
+  MacInstanceType:
+    Type: String
+    Default: mac2-m2.metal
+    Description: >-
+      EC2 Mac instance type. Your account must be entitled for the family and
+      the Availability Zone must have capacity - see the README's "The
+      Dedicated Host comes first" section.
+  BaseImageName:
+    Type: String
+    Default: macos-sequoia-arm64
+    Description: >-
+      Managed base image name. Must match the instance type's architecture -
+      arm64 names for Apple silicon types, x86 names for mac1.metal.
+  AvailabilityZone:
+    Type: String
+    Description: >-
+      Availability Zone for the Dedicated Host. Must match the subnet's zone
+      and offer the instance type.
+  SubnetId:
+    Type: AWS::EC2::Subnet::Id
+    Description: A subnet in the same Availability Zone as the host.
+  SecurityGroupId:
+    Type: AWS::EC2::SecurityGroup::Id
+    Description: >-
+      Security group for the build instance (the API requires one whenever a
+      subnet is specified). No inbound rules are needed - the SSM agent makes
+      outbound connections only.
+  HostId:
+    Type: String
+    Default: ''
+    Description: >-
+      An already-allocated Dedicated Host to build on. Leave empty to have the
+      stack allocate one - note the 24-hour minimum allocation in the README's
+      Cost section before choosing that path.
+  TestAfterBuild:
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
+    Description: >-
+      Run the test phase on a fresh instance launched from the output AMI.
+      The test instance launches on the same host once it finishes scrubbing
+      from the build - that wait runs about 40 minutes on Intel hosts and
+      longer on Apple silicon. Set false to skip tests and end at the build.
+
+Conditions:
+  AllocateHost: !Equals [!Ref HostId, '']
+  TestsEnabled: !Equals [!Ref TestAfterBuild, 'true']
+
+Resources:
+  # Receives the AWSTOE log bundle from each build; the CloudWatch groups
+  # below receive the streamed build output.
+  BuildLogBucket:
+    Type: AWS::S3::Bucket
+    # To keep the bucket when deleting the stack, set DeletionPolicy: Retain.
+    Properties:
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        IgnorePublicAcls: true
+        BlockPublicPolicy: true
+        RestrictPublicBuckets: true
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          # Build logs are only useful for recent troubleshooting - expire
+          # them so the bucket doesn't accumulate cost
+          - Id: ExpireBuildLogs
+            Status: Enabled
+            ExpirationInDays: 30
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+
+  LogBucketTlsPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref BuildLogBucket
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EnforceTls
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::${BuildLogBucket}'
+              - !Sub 'arn:${AWS::Partition}:s3:::${BuildLogBucket}/*'
+            Condition:
+              Bool:
+                aws:SecureTransport: false
+          - Sid: EnforceTlsVersion
+            Effect: Deny
+            Principal: '*'
+            Action: 's3:*'
+            Resource:
+              - !Sub 'arn:${AWS::Partition}:s3:::${BuildLogBucket}'
+              - !Sub 'arn:${AWS::Partition}:s3:::${BuildLogBucket}/*'
+            Condition:
+              NumericLessThan:
+                s3:TlsVersion: 1.2
+
+  InstanceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns:
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/EC2InstanceProfileForImageBuilder'
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+      Policies:
+        - PolicyName: ship-build-logs
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action: s3:PutObject
+                Resource: !Sub 'arn:${AWS::Partition}:s3:::${BuildLogBucket}/*'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action:
+              - sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+      Path: /executionServiceEC2Role/
+
+  InstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: /executionServiceEC2Role/
+      Roles:
+        - !Ref InstanceRole
+
+  # Allocated only when no HostId is supplied. The host bills a 24-hour
+  # minimum (Apple license requirement) and cannot be released before that -
+  # deleting the stack inside the first 24 hours fails on this resource.
+  DedicatedHost:
+    Type: AWS::EC2::Host
+    Condition: AllocateHost
+    Properties:
+      AvailabilityZone: !Ref AvailabilityZone
+      InstanceType: !Ref MacInstanceType
+      # The pipeline targets the host by ID, which works regardless of
+      # auto-placement; off keeps unrelated untargeted launches from
+      # landing on it.
+      AutoPlacement: 'off'
+
+  # Components run as root on macOS. The AWS macOS AMIs ship with Homebrew,
+  # the AWS CLI, the SSM agent, and Xcode Command Line Tools preinstalled -
+  # brew runs as the ec2-user it was installed for, not root.
+  BaselineComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: macos-golden-image-baseline
+      # Components don't accept x wildcards at creation. Keep the version
+      # fixed - the service increments the build number behind it when the
+      # document changes.
+      Version: 1.0.0
+      Platform: macOS
+      Description: Installs a Homebrew package and writes a build marker.
+      Data: |
+        name: macos-golden-image-baseline
+        description: Installs a Homebrew package and writes a build marker.
+        schemaVersion: 1.0
+        phases:
+          - name: build
+            steps:
+              - name: CreateMarkerFolder
+                action: CreateFolder
+                inputs:
+                  - path: /usr/local/lib/golden-image
+              - name: WriteMarker
+                action: CreateFile
+                inputs:
+                  - path: /usr/local/lib/golden-image/baseline.txt
+                    content: baseline applied
+                    overwrite: true
+              - name: InstallJq
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - |
+                      set -e
+                      sudo -iu ec2-user brew install jq
+                      sudo -iu ec2-user brew list --versions jq
+          - name: validate
+            steps:
+              - name: AssertBaseline
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - |
+                      set -e
+                      test -f /usr/local/lib/golden-image/baseline.txt
+                      sudo -iu ec2-user brew list --versions jq
+
+  # The test phase runs on a fresh instance launched from the output AMI,
+  # on the same host once it finishes scrubbing from the build.
+  VerifyComponent:
+    Type: AWS::ImageBuilder::Component
+    Properties:
+      Name: macos-golden-image-verify
+      Version: 1.0.0
+      Platform: macOS
+      Description: Asserts the baseline on a fresh instance from the output AMI.
+      Data: |
+        name: macos-golden-image-verify
+        description: Asserts the baseline on a fresh instance from the output AMI.
+        schemaVersion: 1.0
+        phases:
+          - name: test
+            steps:
+              - name: AssertOnFreshInstance
+                action: ExecuteBash
+                inputs:
+                  commands:
+                    - |
+                      set -e
+                      test -f /usr/local/lib/golden-image/baseline.txt
+                      sudo -iu ec2-user brew list --versions jq
+
+  ImageRecipe:
+    Type: AWS::ImageBuilder::ImageRecipe
+    Properties:
+      Name: macos-golden-image
+      # Changing the recipe replaces it; the x placeholder auto-increments
+      # the version on each replacement.
+      Version: 1.0.x
+      # The managed base image tracks AWS's macOS AMI releases; x.x.x always
+      # resolves to the newest. Building on a macOS version newer than the
+      # latest AWS-published AMI produces an AMI that won't boot on other
+      # hosts - stay on the managed base.
+      ParentImage: !Sub 'arn:${AWS::Partition}:imagebuilder:${AWS::Region}:aws:image/${BaseImageName}/x.x.x'
+      Components:
+        - ComponentArn: !GetAtt BaselineComponent.LatestVersion.Arn
+        - ComponentArn: !GetAtt VerifyComponent.LatestVersion.Arn
+
+  # The placement block is what makes macOS builds work: Mac instances only
+  # run on Dedicated Hosts, so tenancy is host. Pinning the HostId matters
+  # beyond just placement: with a pinned host, Image Builder waits for the
+  # host to finish scrubbing after the build instance terminates, then
+  # launches the test instance on it - one host serves the whole pipeline.
+  # Without a hostId, launches auto-place and don't wait for scrubbing hosts.
+  InfrastructureConfiguration:
+    Type: AWS::ImageBuilder::InfrastructureConfiguration
+    Properties:
+      Name: macos-golden-image
+      InstanceProfileName: !Ref InstanceProfile
+      InstanceTypes:
+        - !Ref MacInstanceType
+      InstanceMetadataOptions:
+        HttpTokens: required
+      # The API requires a security group whenever a subnet is specified.
+      SubnetId: !Ref SubnetId
+      SecurityGroupIds:
+        - !Ref SecurityGroupId
+      Placement:
+        Tenancy: host
+        HostId: !If [AllocateHost, !Ref DedicatedHost, !Ref HostId]
+      Logging:
+        S3Logs:
+          S3BucketName: !Ref BuildLogBucket
+          S3KeyPrefix: macos-golden-image
+
+  DistributionConfiguration:
+    Type: AWS::ImageBuilder::DistributionConfiguration
+    Properties:
+      Name: macos-golden-image
+      Distributions:
+        - Region: !Ref AWS::Region
+          AmiDistributionConfiguration:
+            Name: 'macos-golden-image-{{ imagebuilder:buildDate }}'
+
+  BuildLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/macos-golden-image
+      RetentionInDays: 7
+
+  PipelineLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: /aws/imagebuilder/pipeline/macos-golden-image
+      RetentionInDays: 7
+
+  # No schedule: a scheduled pipeline would launch onto a host you may have
+  # already released. Start builds explicitly while a host is allocated.
+  ImagePipeline:
+    Type: AWS::ImageBuilder::ImagePipeline
+    Properties:
+      Name: macos-golden-image
+      Description: Customized macOS image built on an EC2 Mac Dedicated Host.
+      ImageRecipeArn: !Ref ImageRecipe
+      InfrastructureConfigurationArn: !Ref InfrastructureConfiguration
+      DistributionConfigurationArn: !Ref DistributionConfiguration
+      # Tests default on; false ends the pipeline at the build instance and
+      # skips the scrub wait before the test launch.
+      ImageTestsConfiguration: !If
+        - TestsEnabled
+        - !Ref AWS::NoValue
+        - ImageTestsEnabled: false
+      LoggingConfiguration:
+        ImageLogGroupName: !Ref BuildLogGroup
+        PipelineLogGroupName: !Ref PipelineLogGroup
+
+Outputs:
+  ImagePipelineArn:
+    Description: >-
+      ARN of the image pipeline. Start a build with 'aws imagebuilder
+      start-image-pipeline-execution --image-pipeline-arn <this value>'.
+    Value: !Ref ImagePipeline
+  DedicatedHostId:
+    Description: The Dedicated Host the build runs on.
+    Value: !If [AllocateHost, !Ref DedicatedHost, !Ref HostId]
+  BuildLogBucketName:
+    Description: Bucket receiving the AWSTOE log bundle from each build.
+    Value: !Ref BuildLogBucket


### PR DESCRIPTION
# Description

Adds a golden image example of building macOS AMIs using Image Builder - and how dedicated hosts can be handled. Thoroughly tested in my own account. The template is configurable via parameters to override the host / have the template configure one for you, with adequate warnings around cost / 24 hour minimum restriction for dedicated hosts.

## Checklist

- [X] I deployed this sample in my own account and it created AND deleted cleanly (no leftover AMIs, snapshots, or non-empty buckets beyond what the README documents)
- [X] The README covers prerequisites, deployment, and cleanup for what I changed
- [X] No account IDs, ARNs from real accounts, or credentials anywhere in the change - including test data
- [X] If this adds a sample, it's listed in the root README index

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
