### PR TITLE
Apply small fixes across the repo

### DIFF
--- a/.github/workflows/index.yml
+++ b/.github/workflows/index.yml
@@ -32,8 +32,8 @@ jobs:
               dirs[:] = [d for d in dirs if not d.startswith('.') and d != 'node_modules']
               if root == '.':
                   continue
-              # a sample is a directory with a README plus other files
-              if 'README.md' in files and len(files) > 1:
+              # a sample is a directory with a README
+              if 'README.md' in files:
                   rel = root[2:]
                   if f']({rel}/)' not in readme and f']({rel})' not in readme:
                       missing.append(rel)

--- a/CDK/Linux/accelerated-build-asg/bin/cdk.ts
+++ b/CDK/Linux/accelerated-build-asg/bin/cdk.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import * as cdk from 'aws-cdk-lib/core';
 import { ImageBuilderStack } from '../lib/image-builder-stack';
 

--- a/CDK/Linux/accelerated-build-asg/lambda/ami-update-handler.ts
+++ b/CDK/Linux/accelerated-build-asg/lambda/ami-update-handler.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import {
   EC2Client,
   CreateLaunchTemplateVersionCommand,

--- a/CDK/Linux/accelerated-build-asg/lambda/builder-handler.ts
+++ b/CDK/Linux/accelerated-build-asg/lambda/builder-handler.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import {
   AutoScalingClient,
   DetachInstancesCommand,

--- a/CDK/Linux/accelerated-build-asg/lambda/termination-handler.ts
+++ b/CDK/Linux/accelerated-build-asg/lambda/termination-handler.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import {
   EC2Client,
   TerminateInstancesCommand,

--- a/CDK/Linux/accelerated-build-asg/lib/image-builder-stack.ts
+++ b/CDK/Linux/accelerated-build-asg/lib/image-builder-stack.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import * as cdk from 'aws-cdk-lib/core';
 import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';

--- a/CDK/Linux/accelerated-build-asg/test/ami-update-handler.test.ts
+++ b/CDK/Linux/accelerated-build-asg/test/ami-update-handler.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 const mockSend = jest.fn();
 
 jest.mock('@aws-sdk/client-ec2', () => ({

--- a/CDK/Linux/accelerated-build-asg/test/builder-handler.test.ts
+++ b/CDK/Linux/accelerated-build-asg/test/builder-handler.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 const mockSend = jest.fn();
 
 jest.mock('@aws-sdk/client-auto-scaling', () => ({

--- a/CDK/Linux/accelerated-build-asg/test/image-builder-stack.test.ts
+++ b/CDK/Linux/accelerated-build-asg/test/image-builder-stack.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import * as cdk from 'aws-cdk-lib/core';
 import { Template, Match } from 'aws-cdk-lib/assertions';
 import { ImageBuilderStack } from '../lib/image-builder-stack';

--- a/CDK/Linux/hello-world/bin/aws-ec2-imagebuilder-cdk-example.ts
+++ b/CDK/Linux/hello-world/bin/aws-ec2-imagebuilder-cdk-example.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import { App, Aws } from 'aws-cdk-lib';
 import { ImageBuilderStack } from '../lib/aws-image-builder-stack';
 const accountId = process.env.CDK_DEFAULT_ACCOUNT;

--- a/CDK/Linux/hello-world/lib/aws-image-builder-stack.ts
+++ b/CDK/Linux/hello-world/lib/aws-image-builder-stack.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import { Annotations, Stack, StackProps, Token } from 'aws-cdk-lib';
 import { SecurityGroup, SubnetType, Vpc } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';

--- a/CDK/Linux/hello-world/lib/aws-image-builder.ts
+++ b/CDK/Linux/hello-world/lib/aws-image-builder.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import { Annotations, Aws, CfnMapping, Duration, RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
 import {

--- a/CDK/Linux/hello-world/test/aws-ec2-imagebuilder-cdk-example.test.ts
+++ b/CDK/Linux/hello-world/test/aws-ec2-imagebuilder-cdk-example.test.ts
@@ -1,3 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
 import * as cdk from 'aws-cdk-lib';
 import { Annotations, Match, Template } from 'aws-cdk-lib/assertions';
 import { ImageBuilderStack } from '../lib/aws-image-builder-stack';

--- a/Components/Linux/ram-share-image-component-linux/image-pipeline-app-account-sample.yml
+++ b/Components/Linux/ram-share-image-component-linux/image-pipeline-app-account-sample.yml
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:

--- a/Components/Linux/ram-share-image-component-linux/image-pipeline-shared-account-sample.yml
+++ b/Components/Linux/ram-share-image-component-linux/image-pipeline-shared-account-sample.yml
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:

--- a/Components/Linux/ram-share-image-component-linux/share-images-ram.yml
+++ b/Components/Linux/ram-share-image-component-linux/share-images-ram.yml
@@ -1,3 +1,5 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:

--- a/distribution/cross-account-amis/source-account.yml
+++ b/distribution/cross-account-amis/source-account.yml
@@ -126,6 +126,8 @@ Resources:
     Properties:
       Name: cross-account-distribution-sample
       InstanceProfileName: !Ref InstanceProfile
+      InstanceMetadataOptions:
+        HttpTokens: required
       # Without a default VPC, or to use a different VPC, set a subnet and the
       # security groups to use with it:
       # SubnetId: subnet-...

--- a/quick-start/cdk/lib/quick-start-stack.ts
+++ b/quick-start/cdk/lib/quick-start-stack.ts
@@ -53,9 +53,9 @@ export class QuickStartStack extends cdk.Stack {
     // survived into the image.
     const buildInfoComponent = new imagebuilder.Component(this, 'BuildInfoComponent', {
       componentName: 'quick-start-cdk-build-info',
-      // Components don't accept x wildcards. Keep the version fixed - when
-      // the document changes, the service increments the build number behind
-      // the same version (1.0.0/1, 1.0.0/2, ...), so updates deploy without
+      // Creating a component needs a concrete version (x wildcards are for
+      // references). When the document changes, the service increments the
+      // build number behind the same version, so updates deploy without
       // editing this value.
       componentVersion: '1.0.0',
       platform: imagebuilder.Platform.LINUX,

--- a/quick-start/cloudformation/quick-start.yml
+++ b/quick-start/cloudformation/quick-start.yml
@@ -131,9 +131,9 @@ Resources:
     Type: AWS::ImageBuilder::Component
     Properties:
       Name: quick-start-cfn-build-info
-      # Components don't accept x wildcards. Keep the version fixed - when the
-      # document changes, the service increments the build number behind the
-      # same version (1.0.0/1, 1.0.0/2, ...), and the recipe's LatestVersion
+      # Creating a component needs a concrete version (x wildcards are for
+      # references). When the document changes, the service increments the
+      # build number behind the same version, and the recipe's LatestVersion
       # reference picks that up without editing this value.
       Version: 1.0.0
       Platform: Linux


### PR DESCRIPTION
# Description

- Require IMDSv2 (HttpTokens: required) on the cross-account distribution sample's build instances, matching the repo's newer samples.
- Fix the README index check so it also covers samples whose top-level directory holds only a README plus subdirectories. quick-start, containers, and networking/private-vpc-builds were previously skipped, so a missing index entry for them would have passed silently.
- Add the standard copyright and SPDX license header to the 15 sample source files that were missing it.
- Reword the component-version comments in the quick-start templates to say why the version is fixed (creation needs a concrete version; x wildcards are for references).

## Checklist

- [X] I deployed this sample in my own account and it created AND deleted cleanly (no leftover AMIs, snapshots, or non-empty buckets beyond what the README documents)
- [X] The README covers prerequisites, deployment, and cleanup for what I changed
- [X] No account IDs, ARNs from real accounts, or credentials anywhere in the change - including test data
- [X] If this adds a sample, it's listed in the root README index

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
