### PR TITLE
Fix broken getting-started tutorial link in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository is maintained by the EC2 Image Builder service team. Samples are
 
 ## Start here
 
-New to Image Builder? Build your first image from the console using the [Get started tutorial](https://docs.aws.amazon.com/imagebuilder/latest/userguide/getting-started-image-builder.html) - it's the fastest way to understand the pipeline / recipe / component model before picking up infrastructure-as-code.
+New to Image Builder? Build your first image from the console using the [pipeline wizard tutorial](https://docs.aws.amazon.com/imagebuilder/latest/userguide/start-build-image-pipeline.html) - it's the fastest way to understand the pipeline / recipe / component model before picking up infrastructure-as-code.
 
 From there:
 


### PR DESCRIPTION
# Description

The AWS docs getting-started page for Image Builder was removed in a docs restructure, and its redirect is broken (returns 404). Point the intro link at the console pipeline wizard tutorial, which is the current first-image-from-the-console walkthrough.

## Checklist

- [X] I deployed this sample in my own account and it created AND deleted cleanly (no leftover AMIs, snapshots, or non-empty buckets beyond what the README documents)
- [X] The README covers prerequisites, deployment, and cleanup for what I changed
- [X] No account IDs, ARNs from real accounts, or credentials anywhere in the change - including test data
- [X] If this adds a sample, it's listed in the root README index

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT-0 license.
